### PR TITLE
License on readme, .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,24 @@
+sudo: required
+env:
+  global:
+  - DIST_REPO="f5-sphinx-theme"
+services:
+- docker
+language: python
+python:
+- '2.7'
+before_install:
+- git config --global user.email "OpenStack_TravisCI@f5.com"
+- git config --global user.name "Travis F5 Openstack"
+install:
+- pip install -r requirements.txt
+script:
+- pip install ./
+deploy:
+- provider: pypi
+  user: $PYPI_USER
+  password: $PYPI_PASSWORD
+  server: https://pypi.python.org.pypi
+  on:
+    tags: true
+  skip_cleanup: true

--- a/README.rst
+++ b/README.rst
@@ -43,3 +43,22 @@ After customizing the ``custom.css`` file, you'll have to uninstall the theme an
 Copyright
 ---------
 Copyright 2017 F5 Networks, Inc.
+
+License
+-------
+
+Apache V2.0
+~~~~~~~~~~~
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may
+not use this file except in compliance with the License. You may obtain
+a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+

--- a/f5_sphinx_theme/static/css/custom.css
+++ b/f5_sphinx_theme/static/css/custom.css
@@ -44,6 +44,11 @@ body {
  * Sidebar
  */
 
+.sidebar {
+  background-color: #EBEBEB;
+  z-index: 0;
+}
+
 /* Hide for mobile, show later */
 div.sidebar
 .sidebar {
@@ -55,12 +60,10 @@ div.sidebar
     /* top: 126px; */
     bottom: 0;
     left: 0;
-    z-index: 0;
     display: block;
     padding: 20px;
     overflow-x: hidden;
     overflow-y: auto; /* Scrollable contents if viewport is shorter than content. */
-    background-color: rgb(235, 235, 235);
     border-right: 1px solid #eee;
   }
 }


### PR DESCRIPTION
Problem:
- README was missing License reference
- Repo does not have a travis ci file

Solution:
- Added license text to README
- Added linted .travis.yml

resolves #1 