### PR TITLE
Simple toc with no title

### DIFF
--- a/f5_sphinx_theme/globaltoc.html
+++ b/f5_sphinx_theme/globaltoc.html
@@ -1,0 +1,15 @@
+# Copyright 2017 F5 Networks
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+{{ toctree() }}

--- a/f5_sphinx_theme/localtoc.html
+++ b/f5_sphinx_theme/localtoc.html
@@ -1,0 +1,17 @@
+# Copyright 2017 F5 Networks
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+{%- if display_toc %}
+  {{ toc }}
+{%- endif %}


### PR DESCRIPTION
Problem:
- We do not need the "Table of Contents" title
- toc sidebar should be extensible

Solution:
- added `customtoc.html`
- updated README.rst for conf.py setup

resolves #5 

should be merged AFTER PR #4 

