### PR TITLE
Refactor setup.py for for PyPi upload

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,19 +12,24 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from os import path
 from setuptools import setup
 from f5_sphinx_theme import __version__
 
+here = path.abspath(path.dirname(__file__))
+with open(path.join(here, 'README.rst')) as f:
+    long_description = f.read()
+
 
 setup(
-    name='f5_sphinx_theme',
+    name='f5-sphinx-theme',
     version=__version__,
     url='https://github.com/F5DevCentral/f5-sphinx-theme',
     license='Apache2',
     author='F5 Networks',
     author_email='shawn@f5.com',
     description='Sphinx theme for F5 documentation',
-    long_description=open('README.rst').read(),
+    long_description=long_description,
     zip_safe=False,
     packages=['f5_sphinx_theme'],
     package_data={'f5_sphinx_theme': [
@@ -34,15 +39,15 @@ setup(
         'static/js/*.js',
         'static/fonts/*.*'
     ]},
+    install_requires=['Sphinx>=1.4'],
     include_package_data=True,
     classifiers=[
         'Development Status :: 3 - Alpha',
-        'License :: OSI Approved :: BSD License',
+        'License :: OSI Approved :: Apache Software License',
         'Environment :: Console',
         'Environment :: Web Environment',
         'Intended Audience :: Developers',
         'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3',
         'Operating System :: OS Independent',
         'Topic :: Documentation',
         'Topic :: Software Development :: Documentation',


### PR DESCRIPTION
Issues:
WIP #2 Add Travis-CI integration

Problem:
TravisCI will upload packages to PyPi when they are tagged as releases. Before uploading we need to make sure that our package will have all of the proper licensing, metadata, requirements and README files.

Analysis:
* Added Sphinx >= 1.4 as a install dependancy
* Added the README.rst contents as the long_description for the package so it shows up properly on PyPi
* Fixed the license metadata to be the right version
* Fixed the name of the package to be - instead of _

Tests:
* Uploaded to testpypi.python.org and ensured package was correct
* We cannot test the full install from the test site because the Sphinx package is not uploaded there. We will need to test this with the live server and will do this with pre-release versions.