### PR TITLE
CSS for Callouts, formatting changes, and site_home varaible

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,19 +3,16 @@ F5 Sphinx Theme
 
 Introduction
 ------------
-This repo contains the `sphinx <http://www.sphinx-doc.org/en/stable/index.html>`_
-theme that is used for project documentation that is hosted on the
-`clouddocs.f5.com <http://clouddocs.f5.com>`_ site.
+This repo contains the `sphinx <http://www.sphinx-doc.org/en/stable/index.html>`_ theme used for project documentation hosted on the `clouddocs.f5.com <http://clouddocs.f5.com>`_ site.
 
-This theme should not be used without modification for project documentation
-that is not hosted on the `clouddocs.f5.com <http://clouddocs.f5.com>`_ site.
+This theme should not be used without modification for project documentation that is not hosted on `clouddocs.f5.com <http://clouddocs.f5.com>`_.
 
 Setup and Configuration
 -----------------------
 1. Download or ``git clone`` the f5-sphinx-theme.
-2. ``pip install .`` from the base directory just created.
+2. ``pip install .`` from the f5-sphinx-theme base directory.
 3. ``pip install -r requirements.txt`` to ensure dependencies are present.
-4. Add ``f5-sphinx-theme`` to the "import" section of your project's ``conf.py`` the theme import. ::
+4. Add ``f5-sphinx-theme`` to the "import" section of your project's ``conf.py`` (replace any existing theme import). ::
 
     import f5_sphinx_theme
 
@@ -26,13 +23,13 @@ Setup and Configuration
 
 6. (Optional) Configure the ``html_sidebars`` option. See the `sphinx documentation <http://www.sphinx-doc.org/en/stable/config.html#confval-html_sidebars>`_ for more information. ::
 
-    html_sidebars = {'**': ['searchbox.html', 'localtoc.html']}
+    html_sidebars = {'**': ['searchbox.html', 'localtoc.html', 'globaltoc.html']}
 
-7. (Optional) Configure the ``html_theme_options{}`` dictionary. Currently only the ``site_name`` option is supported. ::
+7. (Optional) Configure the ``html_theme_options{}`` dictionary. Currently, only the ``site_name`` option is supported. ::
 
     html_theme_options = {'site_name': 'My Site Name'}
 
-Depending on your publication / deployment process you may have to re-build your documentation for the changes to take effect.
+Depending on your publication/deployment process, you may have to re-build your documentation for the changes to take effect.
 
 Customizing CSS and Assets
 --------------------------

--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,12 @@ F5 Sphinx Theme
 
 Introduction
 ------------
-This repo contains a F5 Networks branded `sphinx <http://www.sphinx-doc.org/en/stable/index.html>`_ theme to assist with documentation production and delivery for projects already using Sphinx documentation.
+This repo contains the `sphinx <http://www.sphinx-doc.org/en/stable/index.html>`_
+theme that is used for project documentation that is hosted on the
+`clouddocs.f5.com <http://clouddocs.f5.com>`_ site.
+
+This theme should not be used without modification for project documentation
+that is not hosted on the `clouddocs.f5.com <http://clouddocs.f5.com>`_ site.
 
 Setup and Configuration
 -----------------------
@@ -22,6 +27,10 @@ Setup and Configuration
 6. (Optional) Configure the ``html_sidebars`` option. See the `sphinx documentation <http://www.sphinx-doc.org/en/stable/config.html#confval-html_sidebars>`_ for more information. ::
 
     html_sidebars = {'**': ['searchbox.html', 'localtoc.html']}
+
+7. (Optional) Configure the ``html_theme_options{}`` dictionary. Currently only the ``site_name`` option is supported. ::
+
+    html_theme_options = {'site_name': 'My Site Name'}
 
 Depending on your publication / deployment process you may have to re-build your documentation for the changes to take effect.
 

--- a/f5_sphinx_theme/layout.html
+++ b/f5_sphinx_theme/layout.html
@@ -43,7 +43,7 @@
 
 {% block content %}
   <div class="container-fluid">
-    <div class="row table-row">
+    <div class="row">
       <div class="col-sm-3 col-md-3 sidebar">
         <!-- <h4><a href="{{ url_root }}">{{ project }}</a></h4> -->
         <h4>{{ release|striptags|e }}</h4>

--- a/f5_sphinx_theme/layout.html
+++ b/f5_sphinx_theme/layout.html
@@ -45,8 +45,7 @@
   <div class="container-fluid">
     <div class="row">
       <div class="col-sm-3 col-md-3 sidebar">
-        <!-- <h4><a href="{{ url_root }}">{{ project }}</a></h4> -->
-        <h4>{{ release|striptags|e }}</h4>
+         <h4><a href="{{ url_root }}">{{ project }} {{ release }}</a></h4>
         {%- if sidebars != None %}
           {%- for sidebartemplate in sidebars %}
             {%- include sidebartemplate %}
@@ -55,7 +54,7 @@
       </div>
       <div class="col-md-offset-3 col-sm-offset-3 main">
         <h4>
-          <a href="{{ pathto(master_doc) }}">{{ shorttitle|e }}</a>
+          <a href="/">{{ theme_site_name|striptags|e }}</a> &gt; <a href="{{ pathto(master_doc) }}">{{ project|striptags|e }}</a>
           <span class="right"><a href="{{ pathto('genindex')}}">Index</a></span>
         </h4>
         {% block body %}{% endblock %}

--- a/f5_sphinx_theme/localtoc.html
+++ b/f5_sphinx_theme/localtoc.html
@@ -15,5 +15,8 @@
 #}
 
 {%- if display_toc %}
+  <p class="caption">
+   <span class="caption-text">Current Page</span>
+  </p>
   {{ toc }}
 {%- endif %}

--- a/f5_sphinx_theme/searchbox.html
+++ b/f5_sphinx_theme/searchbox.html
@@ -1,0 +1,23 @@
+{#
+    basic/searchbox.html
+    ~~~~~~~~~~~~~~~~~~~~
+
+    Sphinx sidebar template: quick search box.
+
+    :copyright: Copyright 2007-2016 by the Sphinx team, see AUTHORS.
+    :license: BSD, see LICENSE for details.
+#}
+{%- if pagename != "search" and builder != "singlehtml" %}
+<div id="searchbox" style="display: none" role="search">
+  <form class="search" action="{{ pathto('search') }}" method="get">
+    <div>
+      <input type="text" name="q" placeholder="Search" style="padding-left: 6px;"/>
+      <!-- <input type="submit" value="{{ _('Go') }}" style="margin-top: 4px;"/> -->
+      <button type="submit" class="btn btn-primary btn-xs">Go</button>
+    </div>
+    <input type="hidden" name="check_keywords" value="yes" />
+    <input type="hidden" name="area" value="default" />
+  </form>
+</div>
+<script type="text/javascript">$('#searchbox').show(0);</script>
+{%- endif %}

--- a/f5_sphinx_theme/static/css/custom.css
+++ b/f5_sphinx_theme/static/css/custom.css
@@ -112,6 +112,97 @@ div.sidebar
   margin-top: 0;
 }
 
+/*
+* Panels for Tip, See also, Note etc
+*/
+
+
+.admonition {
+  border-radius: 4px;
+  background-color: white;
+  margin-bottom: 20px;
+}
+
+ul.last {
+  margin-left: 26px;
+}
+
+/* Yellow: Attention, Caution, Warning */
+.attention, .caution, .warning {
+  border: 1px #faebcc solid;
+}
+
+.attention>.admonition-title,
+.caution>.admonition-title,
+.warning>.admonition-title {
+  background-color: #fcf8e3;
+  color: #8a6d3b;
+  padding: 6px;
+}
+
+.attention>.last, .caution>.last, .warning>.last {
+  padding: 6px;
+}
+
+/* Red */
+.danger, .error {
+  border: 1px #ebccd1 solid;
+}
+
+.danger>.admonition-title, .error>.admonition-title {
+  background-color: #f2dede;
+  color: #a94442;
+  padding: 6px;
+}
+
+.danger>.last, .error>.last {
+  padding: 6px;
+}
+
+/* Green */
+.hint {
+  border: 1px #d6e9c6 solid;
+}
+
+.hint>.admonition-title {
+  background-color: #dff0d8;
+  color: #3c763d;
+  padding: 6px;
+}
+
+.hint>.last {
+  padding: 6px;
+}
+
+/* Lt. Blue */
+.tip, .note {
+  border: 1px #bce8f1 solid;
+}
+
+.tip>.admonition-title, .note>.admonition-title {
+  background-color: #D9EDF8;
+  color: #31708f;
+  padding: 6px;
+}
+
+.tip>.last, .note>.last {
+  padding: 6px;
+}
+
+/* Blue */
+.important, .seealso {
+  border: 1px #337ab7 solid;
+}
+
+.important>.admonition-title, .seealso>.admonition-title {
+  color: #fff;
+  background-color: #337ab7;
+  padding: 6px;
+}
+
+.important>.last, .seealso>.last {
+  padding: 6px;
+}
 
 /*
  * Placeholder dashboard ideas

--- a/f5_sphinx_theme/static/css/custom.css
+++ b/f5_sphinx_theme/static/css/custom.css
@@ -22,6 +22,14 @@ body {
   padding-top: 0px;
 }
 
+/* Header paragraph links */
+a.headerlink {
+  color: #EBEBEB;
+}
+
+a.headerlink:hover {
+  color: #0083c0;
+}
 
 /*
  * Global add-ons
@@ -49,31 +57,33 @@ form.search {
 }
 
 .sidebar {
+  left: 0;
+  height: 100%;
   background-color: #EBEBEB;
   font-size: 14px;
   z-index: 0;
 }
 
 .sidebar ul {
-  padding: 15px;
+  padding-left: 15px;
 }
 
 /* Hide for mobile, show later */
-div.sidebar
 .sidebar {
   display: none;
 }
 @media (min-width: 768px) {
-  div.sidebar
   .sidebar {
     /* top: 126px; */
+    border-bottom-right-radius: 6px;
+    border-bottom: 1px #4D4F53 solid;
+    border-right: 1px #4D4F53 solid;
     bottom: 0;
     left: 0;
     display: block;
     padding: 20px;
     overflow-x: hidden;
     overflow-y: auto; /* Scrollable contents if viewport is shorter than content. */
-    border-right: 1px solid #eee;
   }
 }
 
@@ -94,7 +104,15 @@ div.sidebar
   background-color: #428bca;
 }
 
+/* Sidebar Search */
+form.search {
+  margin: 6px;
+  padding-bottom: 6px;
+}
 
+.search .btn-primary {
+  border-radius: 4px;
+}
 /*
  * Main content
  */
@@ -205,32 +223,10 @@ ul.last {
 }
 
 /*
- * Placeholder dashboard ideas
+ * Tables
  */
 
-.placeholders {
-  margin-bottom: 30px;
-  text-align: center;
-}
-.placeholders h4 {
-  margin-bottom: 0;
-}
-.placeholder {
-  margin-bottom: 20px;
-}
-.placeholder img {
-  display: inline-block;
-  border-radius: 50%;
+th, td {
+  padding: 4px;
 }
 
-@media (min-width: 768px) {
-  .table-row {
-    display: table;
-    table-layout: fixed;
-  }
-
-  .table-row [class^="col-"] {
-    display: table-cell;
-    float: none;
-  }
-}

--- a/f5_sphinx_theme/static/css/f5.css
+++ b/f5_sphinx_theme/static/css/f5.css
@@ -1019,19 +1019,6 @@ navigation on mobile
   border: none;
   background: #8D8F96;
 }
-.sidebar {
-  /* position: absolute; */
-  /* top: 46px; */
-  left: 0;
-  background: rgba(141, 143, 150, 0.97);
-  /* width: 175px; */
-  /* color: #fff; */
-  /* margin-left: -190px; */
-  height: 100%;
-  z-index: 1000;
-  /* border-top: 16px solid #0194D2; */
-}
-
 
 /* navigation */
 .seemore {
@@ -1110,10 +1097,7 @@ span.a-mm-h {
 .search .btn {
   display: inline;
 }
-.search .btn-primary {
-  padding: 8px 22px !important;
-  border-radius: 0 4px 4px 0;
-}
+
 form.search input.support-guided {
   width: 77%;
   height: 38px;
@@ -4602,6 +4586,7 @@ media styles
     width: 68%;
   }
 }
+/*
 @media (min-width: 1001px) {
   .sidebar-toggle,
   .sidebar {
@@ -4612,6 +4597,7 @@ media styles
     line-height: 20px;
   }
 }
+*/
 @media (min-width: 992px) {
   .col-md-10.middlecontent {
     width: 80%;

--- a/f5_sphinx_theme/theme.conf
+++ b/f5_sphinx_theme/theme.conf
@@ -1,3 +1,6 @@
 [theme]
 inherit = classic
 stylesheet = css/bootstrap.min.css
+
+[options]
+site_name = Cloud Docs Home


### PR DESCRIPTION
@jputrino 

Fixes #3 
Fixes #10 
Fixes #12 

This PR includes minor CSS tweaks for spacing and visual appearance as well as changes to make the Sphinx admonitions look like bootstrap panels and mapped the admonition types to specific colors used by the panels.

Additionally I added the site_home theme option requested in #13 and used it to create a new pseudo-breadcrumb at the top of the doc pages. I also updated the README to reflect this new option.