### PR TITLE
Add 'includehidden' to globaltoc

### DIFF
--- a/f5_sphinx_theme/globaltoc.html
+++ b/f5_sphinx_theme/globaltoc.html
@@ -14,4 +14,4 @@
  limitations under the License.
 #}
 
-{{ toctree() }}
+{{ toctree(includehidden=True) }}


### PR DESCRIPTION
@swormke 

Fixes #14 

## Problem

When a toctree uses the `:hidden:` option, it isn't included in the global toctree.

## Solution

Set the `includehidden` option for the global toctree to True.