### PR TITLE
Fixes #17 - update header and footer

### DIFF
--- a/f5_sphinx_theme/footer.html
+++ b/f5_sphinx_theme/footer.html
@@ -1,3 +1,4 @@
+<footer>
       <div class="container-fluid">
         <div class="row">
           <div class="content-fluid pre-footer">
@@ -99,3 +100,4 @@
 </div>
     </div>
 </div>
+</footer>

--- a/f5_sphinx_theme/header.html
+++ b/f5_sphinx_theme/header.html
@@ -5,7 +5,7 @@
         <div class="container corp-menu">
           <ul>
             <li><a href="https://f5.com" class="internalLink">F5.com</a></li>
-            <li><a href="https://support.f5.comhttps://support.f5.com/csp/home">Support</a></li>
+            <li><a href="https://support.f5.com">Support</a></li>
             <li><a href="https://devcentral.f5.com">Community</a></li>
             <li><a href="https://github.com/F5Networks">GitHub</a></li>
             <li><a href="https://f5.com/about-us/careers">Careers</a></li>
@@ -36,14 +36,14 @@
                           <li><a href="/products/connectors/k8s-bigip-ctlr/latest" data-link-type="Nav: Mega">F5 Kubernetes BIG-IP Controller</a></li>
                           <li><a href="/products/connectors/f5-kube-proxy/latest" data-link-type="Nav: Mega">F5 Kubernetes Proxy</a></li>
                         </ul>
-                        <span class="seemore"><a data-link-type="Nav: Mega" href="/products/connectors">See all </a></span>
+                        <!--span class="seemore"><a data-link-type="Nav: Mega" href="/products/connectors">See all </a></--span-->
                       </li>
                       <li class="divider"></li>
                       <li class="third"><span class="a-mm-h">Application Service Proxy</span>
                         <ul>
                           <li><a href="/products/asp/latest" data-link-type="Nav: Mega">F5 Application Service Proxy</a></li>
                         </ul>
-                        <span class="seemore"><a href="/products/asp/latest">See all </a></span>
+                        <!--span class="seemore"><a href="/products/">See all </a></span-->
                       </li>
                     </ul>
                   </div>
@@ -63,7 +63,7 @@
                           <li><a href="/containers/latest/kubernetes/" data-link-type="Nav: Mega">Kubernetes</a></li>
                           <li><a href="/containers/latest/openshift/" data-link-type="Nav: Mega">RedHat OpenShift</a></li>
                         </ul>
-                        <span class="seemore"><a data-link-type="Nav: Mega" href="/containers/">See all </a></span>
+                        <span class="seemore"><a data-link-type="Nav: Mega" href="/containers/">View details </a></span>
                       </li>
                     </ul>
                   </div>
@@ -79,9 +79,9 @@
                     <ul class="submenu col-sm-11">
                       <li class="third"><span class="a-mm-h">Cloud Integrations</span>
                         <ul>
-                          <li><a href="/cloud/openstack/marathon/" data-link-type="Nav: Mega">OpenStack</a></li>
+                          <li><a href="/cloud/openstack/" data-link-type="Nav: Mega">OpenStack</a></li>
                         </ul>
-                        <span class="seemore"><a data-link-type="Nav: Mega" href="/cloud/">See all </a></span>
+                        <!--span class="seemore"><a data-link-type="Nav: Mega" href="/cloud/">See all </a></span-->
                       </li>
                     </ul>
                   </div>
@@ -97,8 +97,8 @@
                       <li class="third">
                         <span class="a-mm-h">Downloads</span>
                         <ul>
-                          <li><a target="_blank" data-link-type="Nav: Mega" href="https://dockerhub.com/F5Networks" class="internalLink">Docker Hub</a></li>
-                          <li><a target="_blank" data-link-type="Nav: Mega" href="https://dockerstore.com/F5Networks" class="internalLink">Docker Store</a></li>
+                          <li><a target="_blank" data-link-type="Nav: Mega" href="https://hub.docker.com/F5Networks" class="internalLink">Docker Hub</a></li>
+                          <li><a target="_blank" data-link-type="Nav: Mega" href="https://store.docker.com/F5Networks" class="internalLink">Docker Store</a></li>
                         </ul>
                       </li>
                       <li class="divider"></li>


### PR DESCRIPTION
Problem:

There are broken links/links to pages that don't exist in the header. These need to be fixed here so they can be applied to the documentation published on clouddocs.f5.com.

Solution:

The broken links are fixed and the ones that point to nonexistent pages have been commented out. 
I also added a footer tag around the footer html, to match the clouddocs website source html.