### PR TITLE
Turn next/previous links into buttons

### DIFF
--- a/f5_sphinx_theme/layout.html
+++ b/f5_sphinx_theme/layout.html
@@ -60,7 +60,7 @@
         {% block body %}{% endblock %}
         {% if (next or prev) and theme_next_prev_link%}
 		     <div class="row">
-           <div class="col-lg-15">
+           <div class="col-lg-12">
            {% if prev %}
 		        <a href="{{ prev.link|e }}" title="{{ prev.title|striptags|e }}" accesskey="p" class="btn btn-primary pull-left">&lt;&lt; Previous</a>
            {% endif %}

--- a/f5_sphinx_theme/layout.html
+++ b/f5_sphinx_theme/layout.html
@@ -59,15 +59,16 @@
         </h4>
         {% block body %}{% endblock %}
         {% if (next or prev) and theme_next_prev_link%}
-		     <table width=60% border=0 align="left"><tr>
+		     <div class="row">
+           <div class="col-lg-15">
            {% if prev %}
-		        <td align="left"><a href="{{ prev.link|e }}" title="{{ prev.title|striptags|e }}" accesskey="p">&lt;&lt; Previous</a></td>
+		        <a href="{{ prev.link|e }}" title="{{ prev.title|striptags|e }}" accesskey="p" class="btn btn-primary pull-left">&lt;&lt; Previous</a>
            {% endif %}
            {% if next %}
-              <td align="right"><a href="{{ next.link|e }}" title="{{ next.title|striptags|e }}" accesskey="n">Next &gt;&gt;</a></td>
+              <a href="{{ next.link|e }}" title="{{ next.title|striptags|e }}" accesskey="n" class="btn btn-primary pull-right">Next &gt;&gt;</a>
            {% endif %}
-		     </table>
-		     <br>
+		     </div>
+         </div>
         {% endif %}  
       </div>
     </div>


### PR DESCRIPTION
Fixes #27

- make next/previous links pull to the right and left of container, respectively
- turn next/previous links into buttons