### PR TITLE
Add support for font-awesome icons

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -48,6 +48,20 @@ After customizing the ``custom.css`` file, you'll have to uninstall the theme an
     pip uninstall f5-sphinx-theme
     pip install .
 
+Integrated Styling Tools
+------------------------
+The ``f5-sphinx-theme`` is set up to use the Font Awesome integration provided in the `sphinxjp.theme.basicstrap <https://github.com/tell-k/sphinxjp.themes.basicstrap>`_ Sphinx theme/extension. [#sphinxjp]_
+
+To use this extension in your project:
+
+#. Add ``sphinxjp.themes.basicstrap`` to the ``extensions`` section of your project's ``conf.py``.
+#. Add ``sphinxjp.themes.basicstrap`` to your project's ``requirements.txt`` file.
+
+To add a Font Awesome icon to your docs: ::
+
+   :fonticon:`fa fa-<icon_name>`
+
+.. [#sphinxjp] ``sphinxjp.themes.basicstrap`` is licensed under the `MIT license <https://opensource.org/licenses/mit-license.php>`_.
 
 Copyright
 ---------

--- a/f5_sphinx_theme/layout.html
+++ b/f5_sphinx_theme/layout.html
@@ -24,6 +24,7 @@
 # limitations under the License.
 -->
 <link href="https://cdn.f5.com/favicon.ico" rel="icon">
+<script src="https://use.fontawesome.com/21fb8a09c3.js"></script>
 <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
 <!--[if lt IE 9]>
   <script src="https://oss.maxcdn.com/html5shiv/3.7.3/html5shiv.min.js"></script>


### PR DESCRIPTION
Fixes #35 

I added the CDN for font awesome to the extra-head block in f5-sphinx-theme/layout.html. This will allow us to use font-awesome icons in any doc set that uses the f5-sphinx-theme.

Additional config required in the conf.py for each project:
- add [sphinxjp-themes-basicstrap](https://pythonhosted.org/sphinxjp.themes.basicstrap/design.html#font-icon) to the extensions list
- add sphinxjp-themes-basicstrap to requirements.txt 