### PR TITLE
Improve Admonitions and Tables

### DIFF
--- a/f5_sphinx_theme/layout.html
+++ b/f5_sphinx_theme/layout.html
@@ -60,7 +60,7 @@
         </h4>
         {% block body %}{% endblock %}
         {% if (next or prev) and theme_next_prev_link%}
-		     <div class="row">
+		     <div class="row next-prev-btn-row">
            <div class="col-lg-12">
            {% if prev %}
 		        <a href="{{ prev.link|e }}" title="{{ prev.title|striptags|e }}" accesskey="p" class="btn btn-primary pull-left"><i class="fa fa-arrow-circle-left" aria-hidden="true"></i> Previous</a>

--- a/f5_sphinx_theme/static/css/custom.css
+++ b/f5_sphinx_theme/static/css/custom.css
@@ -222,6 +222,45 @@ ul.last {
   padding: 6px;
 }
 
+/* Admonition icons */
+
+.admonition-title:before {
+  font-family: "FontAwesome";
+  display: inline-block;
+  font-style: normal;
+  font-weight: normal;
+  line-height: 1;
+  text-decoration: inherit;
+  margin-left: 8px;
+  margin-right: 8px;
+}
+.attention>.admonition-title:before,
+.caution>.admonition-title:before,
+.warning>.admonition-title:before {
+  content: "\f06a";
+}
+
+.important>.admonition-title:before,
+.note>.admonition-title:before,
+.tip>.admonition-title:before,
+.hint>.admonition-title:before {
+  content: "\f05a";
+}
+
+.danger>.admonition-title:before,
+.error>.admonition-title:before {
+  content: "\f071";
+}
+
+
+.attention>.admonition-title,
+.caution>.admonition-title,
+.warning>.admonition-title {
+  background-color: #fcf8e3;
+  color: #8a6d3b;
+  padding: 6px;
+}
+
 /*
  * Tables
  */

--- a/f5_sphinx_theme/static/css/custom.css
+++ b/f5_sphinx_theme/static/css/custom.css
@@ -259,9 +259,37 @@ ul.last {
 }
 
 /*
+ * Fix margins when .last element is not p in
+ * admonition
+ */
+
+.admonition p.first {
+  margin-left: 0px;
+}
+
+.admonition p {
+  margin-left: 6px;
+  padding: 6px;
+}
+/* End fix */
+
+/*
  * Tables
  */
 
 th, td {
   padding: 4px;
+}
+
+th.stub {
+  background: white;
+  border-right: solid 3px grey;
+}
+
+thead {
+  border-bottom: solid 3px grey;
+}
+
+.next-prev-btn-row {
+  margin-top: 12px;
 }

--- a/f5_sphinx_theme/static/css/custom.css
+++ b/f5_sphinx_theme/static/css/custom.css
@@ -252,15 +252,6 @@ ul.last {
   content: "\f071";
 }
 
-
-.attention>.admonition-title,
-.caution>.admonition-title,
-.warning>.admonition-title {
-  background-color: #fcf8e3;
-  color: #8a6d3b;
-  padding: 6px;
-}
-
 /*
  * Tables
  */

--- a/f5_sphinx_theme/static/css/custom.css
+++ b/f5_sphinx_theme/static/css/custom.css
@@ -147,14 +147,15 @@ ul.last {
 
 /* Yellow: Attention, Caution, Warning */
 .attention, .caution, .warning {
-  border: 1px #faebcc solid;
+  border: 1px #8a6d3b solid;
+  background-color: #fcf8e3;
 }
 
 .attention>.admonition-title,
 .caution>.admonition-title,
 .warning>.admonition-title {
-  background-color: #fcf8e3;
-  color: #8a6d3b;
+  background-color: #8a6d3b;
+  color: white;
   padding: 6px;
 }
 
@@ -162,14 +163,16 @@ ul.last {
   padding: 6px;
 }
 
+
 /* Red */
 .danger, .error {
-  border: 1px #ebccd1 solid;
+  border: 1px #a94442 solid;
+  background-color: #f2dede;
 }
 
 .danger>.admonition-title, .error>.admonition-title {
-  background-color: #f2dede;
-  color: #a94442;
+  background-color: #a94442;
+  color: white;
   padding: 6px;
 }
 
@@ -179,12 +182,13 @@ ul.last {
 
 /* Green */
 .hint {
-  border: 1px #d6e9c6 solid;
+  border: 1px #3c763d solid;
+  background-color: #dff0d8;
 }
 
 .hint>.admonition-title {
-  background-color: #dff0d8;
-  color: #3c763d;
+  background-color: #3c763d;
+  color: white;
   padding: 6px;
 }
 
@@ -194,12 +198,13 @@ ul.last {
 
 /* Lt. Blue */
 .tip, .note {
-  border: 1px #bce8f1 solid;
+  border: 1px #31708f solid;
+  background-color: #D9EDF8;
 }
 
 .tip>.admonition-title, .note>.admonition-title {
-  background-color: #D9EDF8;
-  color: #31708f;
+  background-color: #31708f;
+  color: white;
   padding: 6px;
 }
 
@@ -210,6 +215,7 @@ ul.last {
 /* Blue */
 .important, .seealso {
   border: 1px #337ab7 solid;
+  background-color: #D9EDF8;
 }
 
 .important>.admonition-title, .seealso>.admonition-title {
@@ -259,4 +265,3 @@ ul.last {
 th, td {
   padding: 4px;
 }
-

--- a/f5_sphinx_theme/static/css/f5.css
+++ b/f5_sphinx_theme/static/css/f5.css
@@ -5449,5 +5449,5 @@ body {
 }
 
 tbody tr:nth-child(odd) {
-    background-color: #e6e6e6;
+    background-color: #eeeeee;
 }


### PR DESCRIPTION
Admonition Improvements
--------------------------
- Added appropriate font-awesome icons to .admonition-title[s]
- Changed Admonition coloring to improve readability (IMO)

*Screenshots were taken at 80% zoom in Chrome*

**Before:**
<img width="970" alt="admonition_before" src="https://user-images.githubusercontent.com/13039730/27513478-0d130d7c-592d-11e7-9cb6-667a3d24b9ba.png">

**After:**
<img width="954" alt="admonition_after" src="https://user-images.githubusercontent.com/13039730/27513482-1830372a-592d-11e7-931a-28ed76860f53.png">

Table Improvements
--------------------

- Improved Table readability

**Before:**
<img width="1009" alt="zebra-table-before" src="https://user-images.githubusercontent.com/13039730/27513857-98a9399c-593c-11e7-998c-bf5ef5a970d0.png">

**After:**
<img width="1007" alt="zebra-table-after" src="https://user-images.githubusercontent.com/13039730/27513858-9ce097f8-593c-11e7-93f9-965d717d1ca3.png">

Padding issue
--------------

**Before:**
<img width="288" alt="button_padding-before" src="https://user-images.githubusercontent.com/13039730/27513864-baf66dc6-593c-11e7-8901-023d1c6b1619.png">

**After:**
<img width="281" alt="button_padding-after" src="https://user-images.githubusercontent.com/13039730/27513863-baefb896-593c-11e7-86dc-40807c4cd3a8.png">
