### PR TITLE
Fixed whitespace issue on right side above 1024px screen widths

### DIFF
--- a/f5_sphinx_theme/static/css/f5-theme.css
+++ b/f5_sphinx_theme/static/css/f5-theme.css
@@ -38,7 +38,7 @@ body {
   margin-left: 6px;
 }
 
-@media (min-width: 1024px) {
+@media (min-width: 1025px) {
     #content {
       margin-left: 0;
     }
@@ -130,7 +130,7 @@ a.headerlink:hover {
     }
 }
 
-@media (min-width: 1024px) {
+@media (min-width: 1025px) {
   .site-hidden {
     display: none!important;
   }

--- a/f5_sphinx_theme/static/css/f5-theme.css
+++ b/f5_sphinx_theme/static/css/f5-theme.css
@@ -36,7 +36,6 @@ body {
 
 #content.active {
   margin-left: 6px;
-  width: 100%;
 }
 
 @media (min-width: 1024px) {
@@ -45,16 +44,6 @@ body {
     }
     #content.active {
       margin-left: 256px;
-      padding-right: 20%;
-    }
-}
-
-@media screen and (min-width: 1024px) and (max-width:1200px) {
-    #content {
-      padding-right: 0%;
-    }
-    #content.active {
-      padding-right: 25%;
     }
 }
 


### PR DESCRIPTION
## Reviewers
@jputrino 

## Issue 
There is an excessive amount of whitespace on the v1.0.1 on the right side of the screen. 

Fixes:

### Describe the problem / feature to which this change applies
The issue is from the main content container css being too wide, while the header and footer stop short about 400-500 pixels. It looks like the issue comes from the css specifying that the width should be 100% with having a margin-left attribute, acting as if the container is 100% of the screen width + the margin-left pixels.

### Describe the change(s) made and why
Removed the 100% width attribute from content.active and the padding-right attributes from media queries above 1024px.