### PR TITLE
Fixes #70 - breadcrumb links are broken

### DIFF
--- a/f5_sphinx_theme/breadcrumb.html
+++ b/f5_sphinx_theme/breadcrumb.html
@@ -1,6 +1,6 @@
       <nav class="site-breadcrumb-nav site-nav">
           <ul class="site-breadcrumb-list">
-            <li class="breadcrumb-item"><button type="button" id="sidebarCollapse" class="btn btn-info navbar-btn site-hidden"><i class="fa fa-align-justify"></i></button>&#x20 <a href="{{ url_root }}">{{ theme_site_name|striptags|e }}</a> &gt; <a href="{{ pathto(master_doc) }}">{{ project|striptags|e }} </a> &gt; {{ title|striptags|e }}</li>
+            <li class="breadcrumb-item"><button type="button" id="sidebarCollapse" class="btn btn-info navbar-btn site-hidden"><i class="fa fa-align-justify"></i></button>&#x20 <a href="{{ theme_base_url }}">{{ theme_site_name|striptags|e }}</a> &gt; <a href="{{ pathto(master_doc) }}">{{ project|striptags|e }} </a> &gt; {{ title|striptags|e }}</li>
           </ul>
       </nav>
       

--- a/f5_sphinx_theme/theme.conf
+++ b/f5_sphinx_theme/theme.conf
@@ -1,9 +1,9 @@
 [theme]
 inherit = classic
 stylesheet = css/bootstrap.min.css
-html_last_updated_fmt = ''%Y-%m-%d %I:%M:%S'
 
 [options]
 site_name = CloudDocs Home
 next_prev_link = False
-
+html_last_updated_fmt = '%Y-%m-%d %H:%M:%S'
+base_url = 'http://clouddocs.f5.com'


### PR DESCRIPTION
## Reviewers
`@` mention any reviewer(s) you would like to review your work.

## Issue 
Reference the `#<issueid>`. If your PR does not correspond to an existing Issue, create one before moving forward.

Fixes: #70 

### Describe the problem/feature to which this change applies
- The breadcrumb links are broken.
- The F5 metadata are not formatted correctly.

### Describe the change(s) made and why
I added a new theme option to replace the built-in `url_root` with a user-designated `base_url` and updated the breadcrumb with `theme_base_url` to force the CloudDocs Home link to clouddocs.f5.com.

I updated the metadata tags.

### To do
I need to add a test to verify this behavior automatically. For the time being, it has been manually verified.


