### PR TITLE
Test docs in docker container

### DIFF
--- a/.htmlhintrc
+++ b/.htmlhintrc
@@ -1,0 +1,3 @@
+{
+  "doctype-first": false 
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ script:
 - "./scripts/test-docs-docker.sh"
 - if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then s3-index-generator -b $AWS_S3_BUCKET -t $BRANCH_DIR -r ${DIST_REPO} -i 'index.html'; fi
 after_success:
-- if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then printf "View test documentation at ${S3_DIST_URL}/${UPLOAD_DIR}"; fi
+- if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then printf "View test documentation at ${S3_DIST_URL}/${UPLOAD_DIR}/index.html"; fi
 deploy:
 - provider: script
   on:

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,9 +27,9 @@ script:
 - css-validator f5_sphinx_theme/static/css/custom.css
 - htmlhint f5_sphinx_theme
 - "./scripts/test-docs-docker.sh"
-- if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then "s3-index-generator -b $AWS_S3_BUCKET -t $BRANCH_DIR -r ${DIST_REPO} -i 'index.html'"
+- "if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then s3-index-generator -b $AWS_S3_BUCKET -t $BRANCH_DIR -r ${DIST_REPO} -i 'index.html'; fi"
 after_success:
-- 'if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then printf "View test documentation at ${S3_DIST_URL}/${UPLOAD_DIR}"'
+- 'if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then printf "View test documentation at ${S3_DIST_URL}/${UPLOAD_DIR}"; fi'
 deploy:
 - provider: script
   on:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,14 @@
 sudo: required
 services:
-  - docker
+- docker
 env:
   global:
   - DIST_REPO="f5-sphinx-theme"
   - USER_REPO=$(echo $TRAVIS_REPO_SLUG | cut -f -1 -d / )
-  - BUILD_HTML_DIR=$TRAVIS_BUILD_DIR/test-deploy/docs/_build/html
   - S3_DIST_URL="http://d12ecz1n19ym1p.cloudfront.net"
+  - BUILD_HTML_DIR=${TRAVIS_BUILD_DIR}/test-deploy/docs/_build/html
+  - BRANCH_DIR=${DIST_REPO}/travis-builds/${USER_REPO}/${TRAVIS_BRANCH}/
+  - UPLOAD_DIR="${BRANCH_DIR}$(date +%F)-${TRAVIS_BUILD_NUMBER}"
 
 language: python
 python:
@@ -14,37 +16,25 @@ python:
 before_install:
 - git config --global user.email "OpenStack_TravisCI@f5.com"
 - git config --global user.name "Travis F5"
+- docker pull f5devcentral/containthedocs
 install:
-- gem install html-proofer
+- npm install -g htmlhint
 - npm install -g css-validator
 - npm install -g broken-link-checker
 - pip install -r requirements_test.txt
 - pip install twine
-
 script:
 - css-validator f5_sphinx_theme/static/css/custom.css
-- ./scripts/theme-test.sh
-# Set to allow failure, htmlproofer doesn't support HTML5 tags
-- htmlproofer --check_html --checks-to-ignore "LinkCheck,ImageCheck,ScriptCheck" --report_invalid_tags --report-script-embeds $TRAVIS_BUILD_DIR/html || true
-
-before_deploy:
-- echo "Deploying to ${S3_DIST_URL}/${DIST_REPO}/travis-builds/${USER_REPO}/${TRAVIS_BUILD_NUMBER}/index.html"
+- htmlhint f5_sphinx_theme
+- "./scripts/test-docs-docker.sh"
+- s3-index-generator -b $ARTIFACTS_BUCKET -t $BRANCH_DIR -r ${DIST_REPO} -i 'index.html'
+after_success:
+- printf "View test documentation at ${S3_DIST_URL}/${UPLOAD_DIR}"
 deploy:
-- provider: s3
-  access_key_id: $ARTIFACTS_KEY
-  secret_access_key: $ARTIFACTS_SECRET
-  bucket: $ARTIFACTS_BUCKET
-  skip_cleanup: true
-  local_dir: $TRAVIS_BUILD_DIR/html
-  upload-dir: ${DIST_REPO}/travis-builds/${USER_REPO}/${TRAVIS_BUILD_NUMBER}
-  on:
-    all_branches: true
-    tags: false
 - provider: script
   on:
     repo: f5devcentral/f5-sphinx-theme
     tags: true
-    condition: $TRAVIS_TAG =~ ^v[0-9]+\.[0-9]+.*
+    condition: "$TRAVIS_TAG =~ ^v[0-9]+\\.[0-9]+.*"
   script:
-  - ./scripts/deploy.sh
-    
+  - "./scripts/deploy.sh"

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,9 +27,9 @@ script:
 - css-validator f5_sphinx_theme/static/css/custom.css
 - htmlhint f5_sphinx_theme
 - "./scripts/test-docs-docker.sh"
-- "if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then s3-index-generator -b $AWS_S3_BUCKET -t $BRANCH_DIR -r ${DIST_REPO} -i 'index.html'; fi"
+- if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then s3-index-generator -b $AWS_S3_BUCKET -t $BRANCH_DIR -r ${DIST_REPO} -i 'index.html'; fi
 after_success:
-- 'if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then printf "View test documentation at ${S3_DIST_URL}/${UPLOAD_DIR}"; fi'
+- if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then printf "View test documentation at ${S3_DIST_URL}/${UPLOAD_DIR}"; fi
 deploy:
 - provider: script
   on:

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,9 +27,9 @@ script:
 - css-validator f5_sphinx_theme/static/css/custom.css
 - htmlhint f5_sphinx_theme
 - "./scripts/test-docs-docker.sh"
-- s3-index-generator -b $AWS_S3_BUCKET -t $BRANCH_DIR -r ${DIST_REPO} -i 'index.html'
+- if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then "s3-index-generator -b $AWS_S3_BUCKET -t $BRANCH_DIR -r ${DIST_REPO} -i 'index.html'"
 after_success:
-- printf "View test documentation at ${S3_DIST_URL}/${UPLOAD_DIR}"
+- 'if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then printf "View test documentation at ${S3_DIST_URL}/${UPLOAD_DIR}"'
 deploy:
 - provider: script
   on:

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ script:
 - css-validator f5_sphinx_theme/static/css/custom.css
 - htmlhint f5_sphinx_theme
 - "./scripts/test-docs-docker.sh"
-- s3-index-generator -b $ARTIFACTS_BUCKET -t $BRANCH_DIR -r ${DIST_REPO} -i 'index.html'
+- s3-index-generator -b $AWS_S3_BUCKET -t $BRANCH_DIR -r ${DIST_REPO} -i 'index.html'
 after_success:
 - printf "View test documentation at ${S3_DIST_URL}/${UPLOAD_DIR}"
 deploy:

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -3,3 +3,4 @@ recommonmark
 sphinxjp.themes.basicstrap
 cloud_sptheme
 -e .
+git+https://github.com/nerdoftech/s3_index_generator.git

--- a/scripts/test-docs-docker.sh
+++ b/scripts/test-docs-docker.sh
@@ -20,7 +20,7 @@ RUN_ARGS=( \
   --env-file=.env_travis
 )
 
-printf "Starting Docker container..."
+printf "Starting Docker container..."\n
 
 set -x
 
@@ -39,8 +39,11 @@ git clone https://github.com/jputrino/test-deploy.git
 # build some test docs
 make -C test-deploy/docs/ html 
 
-# deploy test docs to S3
-aws s3 sync test-deploy/docs/_build/html s3://${AWS_S3_BUCKET}/${UPLOAD_DIR}
+# deploy test docs to S3 if we're not in a pull request build
+if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then
+   aws s3 sync test-deploy/docs/_build/html s3://${AWS_S3_BUCKET}/${UPLOAD_DIR}
+   else printf "Skipping deployment because a pull request triggered this build."
+fi
 
 # clean up
 rm -rf .env_travis

--- a/scripts/test-docs-docker.sh
+++ b/scripts/test-docs-docker.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Build some test docs in a container using the theme updates 
+
+# create env file to pass PATH and variables to container
+env | grep -E "^(PATH=)" > .env_travis
+env | grep -E "^(AWS_)" >> .env_travis
+
+set -e
+
+: ${DOC_IMG:=f5devcentral/containthedocs:latest}
+
+RUN_ARGS=( \
+  --rm
+  -i
+  -v $PWD:$PWD
+  --workdir $PWD
+  ${DOCKER_RUN_ARGS}
+  -e "LOCAL_USER_ID=$(id -u)"
+  -e TRAVIS=$TRAVIS
+  --env-file=.env_travis
+)
+
+printf "Starting Docker container..."
+
+set -x
+
+# Run the container using the provided args
+# DO NOT SET -x BEFORE THIS, WE NEED TO KEEP THE CREDENTIALS OUT OF THE LOGS
+docker run "${RUN_ARGS[@]}" ${DOC_IMG} /bin/bash -s <<EOF
+set -x
+set -e
+
+# Install theme project requirements
+pip install --user --upgrade .
+
+# Clone a test docs repo
+git clone https://github.com/jputrino/test-deploy.git 
+
+# build some test docs
+make -C test-deploy/docs/ html 
+
+# deploy test docs to S3
+aws s3 sync test-deploy/docs/_build/html s3://${AWS_S3_BUCKET}/${UPLOAD_DIR}
+
+# clean up
+rm -rf .env_travis
+EOF


### PR DESCRIPTION
## Reviewers
`@` mention any reviewer(s) you would like to review your work.

## Issue 
Reference the `#<issueid>`. If your PR does not correspond to an existing Issue, create one before moving forward.

WIP #75 

### Describe the problem/feature to which this change applies
This change is related to #75 but does not directly address it. 

### Describe the change(s) made and why
I made the following changes below to ensure that test docs are built the same way live docs are -- using the containthedocs docker image. Running the s3 sync from the docker container during the script phase lets me circumvent deployment restrictions applied by travis-ci to pull request builds. This way, we can review the theme changes in the staged test documentation for all builds. 

- Add new test script that builds test docs in a docker container using the updated theme, then deploys them to AWS
- pass vars to docker run command using env file arg
- replaced the HTML checker tool with one that supports HTML5

