### PR TITLE
WIP: Update theme base_url behavior

### DIFF
--- a/f5_sphinx_theme/theme.conf
+++ b/f5_sphinx_theme/theme.conf
@@ -5,4 +5,4 @@ stylesheet = css/bootstrap.min.css
 [options]
 site_name = CloudDocs Home
 next_prev_link = False
-base_url = http://clouddocs.f5.com
+base_url = /


### PR DESCRIPTION
### Describe the change(s) made and why
Do not hard-code the production URL. Use "/" instead.
We don't want to hard-code the production URL. Rather, we want to allow users to set what their sites' base_url is, if desired. 



