### PR TITLE
Restore previous env handling in test-docs-docker script

### DIFF
--- a/scripts/test-docs-docker.sh
+++ b/scripts/test-docs-docker.sh
@@ -2,7 +2,8 @@
 # Build some test docs in a container using the theme updates
 
 # create env file to pass variables to container
-env > .env_file
+env | grep -E "^(PATH=)" > .env_travis
+env | grep -E "^(AWS_)" >> .env_travis
 
 set -e
 
@@ -14,7 +15,7 @@ RUN_ARGS=( \
   -v $PWD:/wkdir
   ${DOCKER_RUN_ARGS}
   -e "LOCAL_USER_ID=$(id -u)"
-  --env-file=.env_file
+  --env-file=.env_travis
 )
 
 printf "Starting Docker container..."\n
@@ -43,5 +44,5 @@ if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then
 fi
 
 # clean up
-rm -rf .env_file
+rm -rf .env_travis
 EOF


### PR DESCRIPTION
## Reviewers
`@` mention any reviewer(s) you would like to review your work.
@nerdoftech FYI

## Issue 
Reference the `#<issueid>`. If your PR does not correspond to an existing Issue, create one before moving forward.

Fixes: N/A


### Describe the problem/feature to which this change applies
The recent change to how env is passed to the docker container in the test-build-script broke the builds. 

See [Travis build 219](https://travis-ci.org/f5devcentral/f5-sphinx-theme/builds/405540703)

### Describe the change(s) made and why

I changed it back to the previous behavior and builds are working again.

