### PR TITLE
style changes

### DIFF
--- a/f5_sphinx_theme/static/css/f5-theme.css
+++ b/f5_sphinx_theme/static/css/f5-theme.css
@@ -22,17 +22,22 @@
   display: flex;
 }
 
-
 body {
   padding: 0 0 0 0;
   width: 100%;
+}
+
+a.copybtn {
+    width: 28px;
+    height: 28px;
+    padding: 8px;
 }
 
 #clouddocs-header {
   position: fixed;
   width: 100%;
   background-color: white;
-  padding-bottom: 20px;
+  z-index: 20;
 }
 
 #clouddocs-footer {
@@ -41,7 +46,7 @@ body {
 
 #content {
   padding: 20px;
-  padding-top: 140px;
+  padding-top: 132px;
   transition: all 0.3s;
 }
 
@@ -52,9 +57,10 @@ body {
 @media (min-width: 1025px) {
     #content {
       margin-left: 0;
+      min-height: 728px;
     }
     #content.active {
-      margin-left: 325px;
+      margin-left: 315px;
     }
 }
 
@@ -130,7 +136,7 @@ a.headerlink:hover {
 
 .nav-sidebartoc a {
   display: table-cell;
-  color: #212121;
+  color: #000;
 }
 
 .nav-sidebartoc a:hover {
@@ -162,21 +168,21 @@ a.headerlink:hover {
 }
 
 #sidebar, .section-nav {
+  width: 320px;
+  margin-right: 20px;
   position: fixed;
   top: 106px;
-  min-width: 256px;
-  max-width: 325px;
   max-height: 80vh;
   transition: all 0.3s;
-  background-color: #f7f7f7;
+  background-color: #fff;
   float: left;
-  margin-right: 40px;
-  margin-top: 22px;
+  /* margin-top: 22px; */
   margin-left: 12px;
   overflow-x: auto;
   overflow-y: scroll;
-  padding: 16px 12px 16px 16px;
-  font-size: 13px;
+  padding: 10px 12px 16px 16px;
+  font-size: 14px;
+  margin-top: 10px;
 }
 
 #sidebar.active {
@@ -191,7 +197,8 @@ a.headerlink:hover {
 }
 
 .nav-sidebartoc > h5 {
-  font-size: 13px;
+  font-size: 14px;
+  color: #000;
 }
 
 @media (max-width: 1024px) {
@@ -364,10 +371,14 @@ ul.site-breadcrumb-list {
     margin: 0;
 }
 
+ul li p {
+  margin-bottom: 0;
+}
+
 .sidebar {
   /*position: fixed;
   right: 0; */
-  width: 35%;
+  width: 300px;
   float: right;
   display: block;
   margin-left: 25px;
@@ -408,10 +419,18 @@ ul.site-breadcrumb-list {
 
 .admonition {
   border-radius: 4px;
-  background-color: white;
+  background-color: #504F4F;
   margin-bottom: 20px;
-  margin-top: 10px;
-  box-shadow: 0 2px 2px rgba(0,0,0,.24), 0 0 2px rgba(0,0,0,.12);
+  margin-top: 20px;
+  box-shadow: 0 0 0 0, 0 0 1px #504F4F;
+  overflow: hidden;
+  max-width: 90%;
+}
+
+.admonition > .admonition-title {
+  font-weight: 600;
+  color: #504F4F;
+  padding: 6px;
 }
 
 div.sidebar ~ div.container.admonition {
@@ -426,39 +445,32 @@ div.sidebar ~ div.container.admonition {
 
 .caution>.admonition-title {
   background-color: #FFF200;
-  color: black;
-  padding: 6px;
 }
 
 /* F5 Orange: Attention, Warning */
 .attention, .warning {
-  border: 1px #f66e41 solid;
   background-color: #FFF;
 }
 
 .attention>.admonition-title,
 .warning>.admonition-title {
-  background-color: #f66e41;
-  color: white;
-  padding: 6px;
+  background-color: #e6e7e8;
+  border-bottom: 2px solid #E4002B;
 }
 
 /* F5 Red */
 .danger, .error {
-  border: 1px #e4002b solid;
   background-color: #FFF;
 }
 
 .danger>.admonition-title, .error>.admonition-title {
-  background-color: #e4002b;
-  color: white;
-  padding: 6px;
+  background-color: #e6e7e8;
+  border-bottom: 2px solid #E4002B;
 }
 
 /* Green */
 .hint,
 .admonition-tmsh {
-  border: 1px #51af4a solid;
   background-color: #FFF;
 }
 
@@ -468,37 +480,32 @@ div.sidebar ~ div.container.admonition {
 
 .hint>.admonition-title,
 .admonition-tmsh>.admonition-title {
-  background-color: #51af4a;
-  color: white;
-  padding: 6px;
+  background-color: #e6e7e8;
+  border-bottom: 2px solid #8547AD;
 }
 
 /* F5 Purple */
 .tip,
 .note {
-  border: 1px #8547AD solid;
   background-color: #FFF;
 }
 
 .tip>.admonition-title, .note>.admonition-title {
-  background-color: #8547AD;
-  color: white;
-  padding: 6px;
+  background-color: #e6e7e8;
+  border-bottom: 2px solid #00A1E4;
 }
 
 
 /* F5 Blue */
 .important,
 .seealso {
-  border: 1px #00A1E4 solid;
   background-color: #FFF;
 }
 
 .important>.admonition-title,
 .seealso>.admonition-title {
-  color: #fff;
-  background-color: #00A1E4;
-  padding: 6px;
+  background-color: #e6e7e8;
+  border-bottom: 2px solid #F3704B;
 }
 
 .attention>.last,
@@ -523,8 +530,8 @@ div.sidebar ~ div.container.admonition {
   font-weight: normal;
   line-height: 1;
   text-decoration: inherit;
-  margin-left: 8px;
-  margin-right: 8px;
+  margin-left: 4px;
+  margin-right: 4px;
 }
 .attention>.admonition-title:before,
 .caution>.admonition-title:before,
@@ -587,11 +594,13 @@ div.sidebar ~ div.container.admonition {
 
 .admonition p.first {
   margin-left: 0px;
+  margin-bottom: 0;
 }
 
 .admonition p {
-  margin-left: 6px;
+  margin-left: 2px;
   padding: 6px;
+  margin-bottom: 0;
 }
 /* End fix */
 
@@ -641,21 +650,13 @@ th.stub {
 */
 .guilabel {
     border: none;
-    background: #ededed;
-    font-size:90%;
     font-weight:700;
     border-radius:4px;
-    padding:2.4px 6px;
-    margin:auto 2px
 }
 .menuselection {
     border: none;
-    background: #ededed;
-    font-size:90%;
     font-weight:700;
     border-radius:4px;
-    padding:2.4px 6px;
-    margin:auto 2px
 }
 
 /*end elements from sphinx-rtd-theme*/
@@ -670,29 +671,30 @@ h1,
 h2,
 h3,
 .nav-sidebartoc > h5  {
-  font-family: 'TabletGothicSemiBold', 'Colaborate', Arial, sans-serif;
-  font-weight: normal !important;
-  color: #333;
+  font-family: Proxima,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
+  font-weight: 400;
+  color: #000;
 }
 h4 {
-  font-family: Arial, sans-serif;
   font-weight: normal !important;
   color: #000;
 }
 h1 {
-  font-size: 25px;
+  font-size: 34px;
+  margin-bottom: 18px;
+
 }
 h2 {
-  font-size: 22px;
-  line-height: 26px;
-  margin-bottom: 20px;
+  font-size: 28px;
+  margin-bottom: 18px;
   width: 100%;
 }
 h3 {
-  font-size: 20px;
+  font-size: 22px;
+  margin-bottom: 16px;
 }
 h4 {
-  font-size: 18px;
+  font-size: 16px;
   margin: 18px 0 10px 0;
   width: 100%;
 }
@@ -720,6 +722,10 @@ caption {
 
 ol.arabic {
   padding-left: 20px;
+}
+
+ol > li {
+  margin-bottom: 11px;
 }
 
 /*
@@ -751,26 +757,22 @@ formatting for using sidebar class with admonitions
 table {
   width: auto;
   overflow: scroll;
-  border: 1px solid #00A1E4;
   border-spacing: 0;
-  margin-bottom: 22px;
-  margin-top: 16px;
+  margin-bottom: 12px;
+  margin-top: 0px;
   border-collapse: collapse;
   border-radius: 4px;
-  box-shadow: 0 2px 2px rgba(0,0,0,.24), 0 0 2px rgba(0,0,0,.12);
+  border: 1px solid #94a4b5;
   word-wrap: break-word;
 }
 
 table thead th {
-  background: #00A1E4;
-  border: none;
-  color: #fff;
-  font-size: 14px;
-  font-weight: 500;
+  background: #D9D5D5;
+  color: #504F4F;
+  font-weight: 600;
   line-height: 24px;
-  padding: 8px 24px;
+  padding: 3px 10px;
   text-align: left;
-  text-transform: uppercase;
 }
 
 table tbody tr {
@@ -778,8 +780,7 @@ table tbody tr {
 }
 
 table tbody td {
-  border: 1px solid rgba(207,216,220,.24);
-  padding: 8px 24px;
+  padding: 3px 10px;
   text-align: left;
 }
 
@@ -787,7 +788,6 @@ tr,
 tbody tr:nth-child(odd),
 tbody tr:nth-child(even) {
   background: #FFF;
-  border-top: 1px solid #9c9aa3;
 }
 
 img {
@@ -819,7 +819,7 @@ code,
   border-radius: 0;
   color: #000;
   border: 0;
-  background: rgba(0,0,0,0);
+  background: #e4e4e4;
 }
 
 div[class^='highlight'] > table {
@@ -869,6 +869,7 @@ pre,
   border: 0;
   background: #e4e4e4;
   padding: 10px;
+  padding-right: 28px;
 }
 
 .literal-block-wrapper + .docutils + .container {
@@ -923,7 +924,7 @@ dl > dd > table > tbody > tr:nth-child(odd) > td.field-body > ul {
 
 .pageHeader {
   height: 60px;
-  border-bottom: 10px solid #2270B3;
+  border-bottom: 4px solid #2270B3;
   padding-top: 4px;
 }
 

--- a/f5_sphinx_theme/static/css/f5.css
+++ b/f5_sphinx_theme/static/css/f5.css
@@ -1,6 +1,69 @@
-/*
- * Copyright 2017 F5 Networks
- */
+/* Start of grid layout for CONTAINER AND CLOUD SOLUTIONS page  */
+
+.panel-body > .list-group {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
+.panel-body > .list-group .btn {
+  white-space: normal;
+}
+
+.panel-body > .list-group .list-group-item:nth-child(4n+1) {
+  margin-left: 0;
+}
+
+.panel-body > .list-group .list-group-item {
+  margin-top: 10px;
+  width: calc(25% - 20px);
+  margin-left: 20px;
+  overflow: hidden;
+  background-color: #f7f7f7;
+  border: none;
+  text-align: center;
+  padding: 25px;
+}
+
+.panel-body > .list-group-item *:last-child{
+  margin-bottom: 0;
+}
+
+.panel-body > .list-group-item *:first-child  {
+  margin-top: 0;
+}
+
+.panel-body > .list-group .list-group-item p {
+  margin-top: 12px;
+  font-size: 14px;
+}
+
+.panel-heading > .panel-title {
+  text-align: center;
+}
+
+/* Responsive for smaller screens */
+
+@media all and (max-width: 1024px) {
+  .panel-body > .list-group .list-group-item {
+    width: calc(33% - 20px);
+  }
+}
+
+@media all and (max-width: 839px) {
+  .panel-body > .list-group .list-group-item {
+    width: calc(50% - 20px);
+  }
+}
+
+@media all and (max-width: 480px) {
+  .panel-body > .list-group .list-group-item {
+    width: calc(100% - 20px);
+  }
+}
+
+/* End of grid layout for CONTAINER AND CLOUD SOLUTIONS page */
+
 body.newstyles {
   margin: 0;
   padding: 0;
@@ -55,12 +118,11 @@ body.newstyles {
 h1,
 h2,
 h3 {
-  font-family: 'TabletGothicSemiBold', 'Colaborate', Arial, sans-serif;
+  font-family: Proxima,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
   font-weight: normal !important;
   color: #333;
 }
 h4 {
-  font-family: 'Colaborate', Arial, sans-serif;
   font-weight: normal !important;
   color: #000;
 }
@@ -531,7 +593,8 @@ a.mysupport:hover {
 .footer {
   background: #4c4e52;
   color: #fff;
-  margin-top: 0px;
+  margin-top: 80px;
+  position: sticky;
 }
 .footer p,
 footer p a {
@@ -588,6 +651,19 @@ footer p a {
 .footer .revision {
   color: #4c4e4e;
 }
+#MainMenu .submenu > li:not(.divider) {
+  padding: 15px;
+  background: #efefef;
+}
+#MainMenu > li {
+  margin-top: 10px;
+  height: 42px;
+}
+#MainMenu > li:hover::after {
+  content: " ";
+  display: block;
+  border-bottom: 3px solid #e21d38;
+}
 .main-menu {
   float: left;
   margin: 8px 0 0 0;
@@ -626,14 +702,12 @@ footer p a {
   line-height: 21px;
   vertical-align: text-top;
   font-size: 18px !important;
-  font-family: 'TabletGothic', 'Colaborate', Arial, sans-serif;
-  font-weight: 300;
 }
 .main-menu li a {
-  color: #555;
-  font-weight: bold;
+  color: #000;
+  font-size: 16px;
+  text-transform: uppercase;
   text-decoration: none;
-  line-height: 60px;
 }
 .main-menu li a:hover {
   color: #0075b8;
@@ -657,7 +731,7 @@ footer p a {
   text-align: center;
   position: absolute;
   width: 100%;
-  bottom: 0;
+  bottom: -20px;
   left: 0;
   display: none;
 }
@@ -669,7 +743,7 @@ footer p a {
   height: 0;
   border-left: 7px solid transparent;
   border-right: 7px solid transparent;
-  border-bottom: 7px solid #e4e7eb;
+  border-bottom: 7px solid #fff;
 }
 .main-menu li:hover .menu-panel {
   display: block;
@@ -681,12 +755,13 @@ footer p a {
   position: absolute;
   z-index: 1000;
   left: 0;
-  background: #e4e7eb;
+  background: #fff;
+  border-top: 1px solid #e4e7eb;
   width: 100%;
   box-shadow: 0 2px 5px 0 rgba(0, 0, 0, 0.25);
   padding: 30px 0;
   min-height: 244px;
-  margin: -2px 0 0 0;
+  margin: 20px 0 0 0;
 }
 .main-menu li:hover .indicator {
   display: block;
@@ -709,10 +784,8 @@ footer p a {
 }
 .main-menu .submenu > li > a,
 .main-menu .submenu > li a.header {
-  font-family: "TabletGothicSemiBold", 'Colaborate', Arial, sans-serif;
   text-transform: uppercase;
   font-size: 16px;
-  font-weight: bold;
   margin: 4px 0 10px 0;
   float: left;
 }
@@ -721,7 +794,7 @@ footer p a {
   float: left;
 }
 .main-menu .submenu > li.divider {
-  margin: 0 1.8% !important;
+  margin: 0 10px;;
   padding: 0;
   border-left: #FFF solid 1px;
   width: 1px;
@@ -739,6 +812,7 @@ footer p a {
   /*color: #4d4f53;*/
   color: #004A90;
   text-decoration: none;
+  text-transform: none;
   line-height: 16px;
   padding-bottom: 4px;
 }
@@ -753,7 +827,7 @@ footer p a {
   margin: 0;
   list-style: none;
   line-height: 20px;
-  padding: 0 0 4px 0 !important;
+  padding: 0 0 4px 0;
 }
 .main-menu .submenu li ul li a {
   font-weight: normal;
@@ -785,7 +859,7 @@ footer p a {
 }
 .pageHeader {
   height: 80px;
-  border-bottom: 14px solid #2270B3;
+  border-bottom: 4px solid #2270B3;
 }
 .section {
   width: 100%;
@@ -811,18 +885,17 @@ img.logo.support {
 /* ---------- corporate menu ----------  */
 .corp-header {
   height: 46px;
-  background-color: #ebebeb;
 }
 .corp-header .corp-menu li:before {
   content: "|";
   padding-right: 8px;
   color: #888;
-  float: left;
+  /* float: left; */
   line-height: 18px;
 }
 .corp-header .corp-menu li:first-child:before {
   content: "";
-  float: left;
+  /* float: left; */
   line-height: 18px;
 }
 .corp-header ul li a.current {
@@ -831,10 +904,9 @@ img.logo.support {
 }
 .corp-header ul li a {
   padding: 0;
-  color: #000;
-  font-weight: bold;
-  font-size: 12px;
-  opacity: 0.8;
+  color: #808285;
+  font-size: 14px;
+  text-transform: uppercase;
   transition: opacity 1s ease-in-out;
   -moz-transition: opacity 1s ease-in-out;
   -webkit-transition: opacity 1s ease-in-out;
@@ -1004,7 +1076,6 @@ navigation on mobile
   margin: -5px 0 0 0;
 }
 /*--- sidebar on mobile -- */
-
 .sidebar-toggle {
   position: absolute;
   top: 3px;
@@ -1019,7 +1090,18 @@ navigation on mobile
   border: none;
   background: #8D8F96;
 }
-
+/* .sidebar {
+  position: absolute;
+  top: 46px;
+  left: 0;
+  background: rgba(141, 143, 150, 0.97);
+  width: 175px;
+  color: #fff;
+  margin-left: -190px;
+  height: 100%;
+  z-index: 1000;
+  border-top: 16px solid #0194D2;
+} */
 /* navigation */
 .seemore {
   float: left;
@@ -1042,10 +1124,9 @@ navigation on mobile
 }
 a.mn-h,
 span.a-mm-h {
-  font-family: "TabletGothicSemiBold", 'Colaborate', Arial, sans-serif;
   text-transform: uppercase;
   font-size: 16px;
-  font-weight: bold;
+  color: #000;
   display: block;
   line-height: 16px;
   padding-bottom: 4px;
@@ -1097,7 +1178,10 @@ span.a-mm-h {
 .search .btn {
   display: inline;
 }
-
+.search .btn-primary {
+  padding: 8px 22px !important;
+  border-radius: 0 4px 4px 0;
+}
 form.search input.support-guided {
   width: 77%;
   height: 38px;
@@ -1302,15 +1386,14 @@ h3 .glyphicon {
 }
 .content-fluid.pre-footer {
   background: #00b0ed;
+  margin: 20px 0 -120px 0;
 }
 .blocks-container {
   position: relative;
   /*background: #00b0ed;*/
   width: 100%;
   max-width: 1200px;
-  /*margin: 0 10px 0 0;*/
-  margin-right: auto;
-  margin-left: auto;
+  margin: 40px auto;
   display: table;
   /*border-radius: 4px;*/
   padding: 10px 0 14px 0;
@@ -4586,7 +4669,6 @@ media styles
     width: 68%;
   }
 }
-/*
 @media (min-width: 1001px) {
   .sidebar-toggle,
   .sidebar {
@@ -4597,7 +4679,6 @@ media styles
     line-height: 20px;
   }
 }
-*/
 @media (min-width: 992px) {
   .col-md-10.middlecontent {
     width: 80%;
@@ -5421,33 +5502,29 @@ a.no-decoration:active {
     font-family: Proxima;
     font-weight: 400;
     font-style: normal;
-    src: url(/_static/fonts/ProximaMedium.woff2) format('woff2'), url(/_static/fonts/ProximaMedium.woff) format('woff')
+    src: url(/assets/fonts/ProximaMedium.woff2) format('woff2'), url(/assets/fonts/ProximaMedium.woff) format('woff')
 }
 
 @font-face {
     font-family: Proxima;
     font-weight: 700;
     font-style: normal;
-    src: url(/_static/fonts/ProximaBold.woff2) format('woff2'), url(/_static/fonts/ProximaBold.woff) format('woff')
+    src: url(/assets/fonts/ProximaBold.woff2) format('woff2'), url(/assets/fonts/ProximaBold.woff) format('woff')
 }
 
 @font-face {
     font-family: Proxima;
     font-weight: 100;
     font-style: normal;
-    src: url(/_static/fonts/ProximaThin.woff2) format('woff2'), url(/_static/fonts/ProximaThin.woff) format('woff')
+    src: url(/assets/fonts/ProximaThin.woff2) format('woff2'), url(/assets/fonts/ProximaThin.woff) format('woff')
 }
 
 body {
-    font-family: Proxima, "Helvetica Neue", Helvetica, Arial, "Lucida Grande", sans-serif;
+    font-family: Proxima,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
     font-size: 16px;
     font-weight: 400;
     line-height: 1.375;
     color: #4D4F53;
     background-color: #FFF;
     position: relative
-}
-
-tbody tr:nth-child(odd) {
-    background-color: #eeeeee;
 }

--- a/f5_sphinx_theme/static/js/clouddocs.js
+++ b/f5_sphinx_theme/static/js/clouddocs.js
@@ -29,41 +29,65 @@ $(document).ready(function () {
 
 });
 
-//Resize sidebar if the footer covers it
+// Function to resize the sidebar if the footer covers it
+function resizeScrollbar() {
+  //Set the max heigh as either the content max height or the css max-height property
+  var contentHeight = 0;
+  if ($(".nav-sidebartoc").height() < parseInt($("#sidebar").css('max-height'))) {
+    contentHeight = $(".nav-sidebartoc").height();
+  }else {
+    contentHeight = $("#sidebar").css('max-height');
+  }
+  contentHeight = parseInt(contentHeight);
+
+  //get the sidebar bottom offset and the footer top offset
+  var sidebarBottom = $("#sidebar").offset().top + $("#sidebar").outerHeight(true) - 25;
+  var footerTop = $("#clouddocs-footer").offset().top;
+
+  //if checks if there is a collision, if so then shrink the sidebar
+  if (sidebarBottom >= footerTop) {
+    var shorterNewHeight = $("#sidebar").height() - (sidebarBottom - footerTop) - 40;
+    $("#sidebar").height(shorterNewHeight);
+
+  //checks if the footer has moved away, so the sidebar needs to grow back
+  }else if($("#sidebar").height() < contentHeight) {
+    var tallerNewHeight = $("#sidebar").height() + (footerTop - sidebarBottom) - 40;
+    if (tallerNewHeight > contentHeight) {
+      $("#sidebar").height(contentHeight + 40);
+    }else {
+      $("#sidebar").height(tallerNewHeight);
+    }
+  }
+
+  if($("#sidebar").height() < 140) {
+    console.log("height is too short!");
+    $("#sidebar").height(160);
+  }
+}
+
+//Calls sidebar resize function on page load and when there is scrolling
 $(document).ready(function () {
+
+  /* JavaScript Media Queries, check if mobile view and do not resize TOC */
+  if (matchMedia) {
+  	const mq = window.matchMedia("(max-width: 768px)");
+  	mq.addListener(WidthChange);
+  	WidthChange(mq);
+  }
+
+  // Checks if resize TOC should be called when page is resized
+  function WidthChange(mq) {
+  	if (!mq.matches) {
+      console.log("im resizing the TOC");
+  	  resizeScrollbar();
+  	}
+  }
 
   //Throttle for scroll
   $(window).scroll(function() {
   clearTimeout($.data(this, 'scrollTimer'));
     $.data(this, 'scrollTimer', setTimeout(function() {
-
-    //Set the max heigh as either the content max height or the css max-height property
-    var contentHeight = 0;
-    if ($(".nav-sidebartoc").height() < parseInt($("#sidebar").css('max-height'))) {
-      contentHeight = $(".nav-sidebartoc").height();
-    }else {
-      contentHeight = $("#sidebar").css('max-height');
-    }
-    contentHeight = parseInt(contentHeight);
-
-    //get the sidebar bottom offset and the footer top offset
-    var sidebarBottom = $("#sidebar").offset().top + $("#sidebar").outerHeight(true) - 25;
-    var footerTop = $("#clouddocs-footer").offset().top;
-
-    //if checks if there is a collision, if so then shrink the sidebar
-    if (sidebarBottom >= footerTop) {
-      var shorterNewHeight = $("#sidebar").height() - (sidebarBottom - footerTop) - 40;
-      $("#sidebar").height(shorterNewHeight);
-
-    //checks if the footer has moved away, so the sidebar needs to grow back
-    }else if($("#sidebar").height() < contentHeight) {
-      var tallerNewHeight = $("#sidebar").height() + (footerTop - sidebarBottom) - 40;
-      if (tallerNewHeight > contentHeight) {
-        $("#sidebar").height(contentHeight + 40);
-      }else {
-        $("#sidebar").height(tallerNewHeight);
-      }
-    }
+      resizeScrollbar();
   }, 250));
   });
 });


### PR DESCRIPTION
## Reviewers
@jputrino 

## Style changes:
Font changed to be F5 standard (some limitations on license; using same fonts as DevCentral)
Heading sizes changed so they're easier to differentiate between (and padding added around them)
:guilabel: is now plain text bold
``code`` is now grey background that matches code-block
Admonitions (note, important, tip, etc) changed to grey with accent color, less padding, 90% instead of full width
Table changes: header color, thin border, border between rows, less padding
version sidebar made a bit smaller
Heading menu updated to have F5 look and feel
Copy code button css updates. Copy code functionality is part of container so styles should be good when the extension is added to container (soon).

## Bug fixes:
Footer for short pages stays at the bottom of the page (previously it would float up and chop off TOC)
All ordered lists have consistent spacing (previously when you had additional text in an ordered list it expanded, when no text, it contracted)
TOC pane now has a consistent width (previously it changed based on topic)


