### PR TITLE
correct development status string

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ setup(
     classifiers=[
         'Framework :: Sphinx',
         'Framework :: Sphinx :: Theme',
-        'Development Status ::  4 - Beta',
+        'Development Status :: 4 - Beta',
         'License :: OSI Approved :: Apache Software License',
         'Environment :: Console',
         'Environment :: Web Environment',


### PR DESCRIPTION
## Description
CI/CD pipeline failed deploy to pip repo due to an extra space character in Development Status string

Please review and merge the change