### PR TITLE
CLDOCS-121: Make TOCs more narrow

### DIFF
--- a/f5_sphinx_theme/static/css/f5-theme.css
+++ b/f5_sphinx_theme/static/css/f5-theme.css
@@ -63,7 +63,7 @@ a.copybtn {
     }
     #content.active {
       margin-left: 315px;
-      margin-right: 337px
+      margin-right: 275px
     }
 }
 
@@ -437,7 +437,6 @@ ul li p {
 
 #right-sidebar{
    right:0px;
-   background-color:#F1F1F1;
 }
 
 #right-sidebar hr {
@@ -450,7 +449,7 @@ ul li p {
 }
 
 #right-sidebar, .section-nav {
-  width: 320px;
+  width: 280px;
   display: block;
   margin-right: 20px;
   position: fixed;
@@ -461,7 +460,7 @@ ul li p {
   /* margin-top: 22px; */
   margin-left: 20px;
   overflow-x: auto;
-  overflow-y: scroll;
+  overflow-y: auto;
   padding: 10px 10px 16px 16px;
   font-size: 14px;
   margin-top: 10px;
@@ -1039,7 +1038,6 @@ ol > li:nth-child(1) > div > div > pre,
 div[class^='highlight'] > div > pre,
 pre,
 .span.pre {
-  white-space: pre-wrap;
   border: 0;
   background: #e4e4e4;
   padding: 10px;


### PR DESCRIPTION
### Summary 

This change is intended to make content area wider by shrinking right-sidebar and making content area margin less. Also, it includes fix for layout issue with line-numbered code-blocks 


### Changes: 

 - Update width of right-sidebar
 - Update margin for content area
 - Make scroll enabled automatically on right sidebar
 - Remove white-space: pre-wrap 