### PR TITLE
CLDOCS-125: Add blue bar on corp header for 

### DIFF
--- a/f5_sphinx_theme/layout.html
+++ b/f5_sphinx_theme/layout.html
@@ -51,11 +51,6 @@
 
   {%- if sidebars != None %}
     {%- block f5sidebar %}
-    <div id="dismiss">
-      <button type="button" class="btn btn-info navbar-btn site-hidden">
-        <i class="fa fa-align-justify"></i>
-      </button>
-    </div>
     <div id="sidebar" class="section-nav">
       {% if (theme_version_selector) %}
       <!--  version selector ------------------>

--- a/f5_sphinx_theme/static/css/f5-theme.css
+++ b/f5_sphinx_theme/static/css/f5-theme.css
@@ -1183,10 +1183,7 @@ table.docutils.footnote, table.docutils.footnote > tbody, table.docutils.footnot
   .docs-container {
     margin-left: 0px;
   }
-  #sidebarCollapse {
-    visibility: hidden;
-    display: none;
-  }
+
   .site-article-inner {
     width: 100%;
   }

--- a/f5_sphinx_theme/static/css/f5.css
+++ b/f5_sphinx_theme/static/css/f5.css
@@ -865,9 +865,32 @@ footer p a {
     width: 28%;
   }
 }
-.pageHeader {
-  height: 80px;
-  border-bottom: 14px solid #0186be;
+@media (max-width: 767px) {
+
+  .corp-header {
+    height: 40px;
+    background-color: #ebebeb;
+    border-bottom: 14px solid #0186be;
+  }
+
+    .pageHeader {
+      height: 80px;
+    }
+
+}
+
+@media (min-width: 768px) {
+
+  .corp-header {
+    height: 40px;
+    background-color: #ebebeb;
+  }
+
+   .pageHeader {
+      height: 80px;
+      border-bottom: 14px solid #0186be;
+   }
+
 }
 .section {
   width: 100%;


### PR DESCRIPTION
### Summary 

This change is intended for adding blue bar to corp header when page is loaded on mobile devices. Also, it removes extra navigation button which is currently hidden under the page header and gets shown/rendered when page is loaded on mobile devices since the page header gets hidden on mobile version.

This change is related to https://jira.pdsea.f5net.com/browse/CLDOCS-125

### Changes 

 * remove extra button from layout.html
 * update CSS style to disable hiding of blue navigation button located on left side of breadcrumb
 * update CSS style  to enable blue bar on corp header when page is loaded on mobile device


### Additional information