### PR TITLE
Removed a reference to index.css file in layout.html

### DIFF
--- a/f5_sphinx_theme/__init__.py
+++ b/f5_sphinx_theme/__init__.py
@@ -16,7 +16,7 @@ import os
 from os import path
 
 
-__version__ = "2.0.7"
+__version__ = "2.0.8"
 
 def get_html_theme_path():
     """Return the html theme path for this template library.

--- a/f5_sphinx_theme/layout.html
+++ b/f5_sphinx_theme/layout.html
@@ -7,7 +7,6 @@
 {% set css_files = css_files +
   [ "/assets/css/bootstrap.min.css",
     "/assets/css/f5.css",
-    "/assets/css/index.css",
     "/assets/css/f5-theme.css",
     "/assets/css/CoveoFullSearch.css",
     "_static/css/custom.css",


### PR DESCRIPTION
## Reviewers
@alankrit8 

Fixes:

In `f5_sphinx_theme/layout.html`, there was a reference to `/assets/css/index.css`. This file no longer exists in `f5_sphinx_theme/static/css`.

When the html is built via sphinx, there will be a link that referencing to a missing file (`/assets/css/index.css`). It looks like this file was removed and the reference in `layout.html` was missed.

I was able to track the following commit shown [here](https://github.com/f5devcentral/f5-sphinx-theme/commit/cd418b5dfcf076881cb0d2ba9e302df8ded1b7ca) but I am not sure why this line was added or what it added. I looked internally for `index.css` but can't seem to find it.



