### PR TITLE
Updating CI so focal distro images is used with python 2.7, 3.6, and 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 sudo: required
+dist: bionic
 services:
 - docker
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 sudo: required
-dist: focal
 services:
 - docker
 env:
@@ -12,6 +11,8 @@ env:
 
 language: python
 python:
+  - "2.7"
+  - "3.6"
   - "3.7"
 
 before_install:
@@ -50,3 +51,4 @@ deploy:
       repo: f5devcentral/f5-sphinx-theme
       tags: true
       condition: $TRAVIS_TAG =~ ^v[0-9]+\.[0-9]+\.[0-9]*|^.*-stable$|master
+      python:  '3.7'


### PR DESCRIPTION
## Reviewers
@alankrit8 

## Issue 
Travis CI was failing during deployment to PyPi

Fixes:
Updated CI build image to use `bionic` instead of the `xenial` default.

### Describe the problem/feature to which this change applies
The pipeline suddenly failed to deploy to PyPi with the following error message.
```shell
Installing deploy dependencies
Successfully installed dpl-pypi-1.10.16
1 gem installed
2022-04-05 20:51:56 URL:https://bootstrap.pypa.io/get-pip.py [2658865/2658865] -> "-" [1]
ERROR: This script does not work on Python 3.6 The minimum supported Python version is 3.7. Please use https://bootstrap.pypa.io/pip/3.6/get-pip.py instead.
Couldn't install pip, setuptools, twine or wheel.

failed to deploy
```

### Describe the change(s) made and why
Updating the Travis CI image from using `xenial` to `bionic`