### PR TITLE
fix: Need to also check when pathname contains more than 3 paths

### DIFF
--- a/f5_sphinx_theme/__init__.py
+++ b/f5_sphinx_theme/__init__.py
@@ -16,7 +16,7 @@ import os
 from os import path
 
 
-__version__ = "2.1.0"
+__version__ = "2.1.1"
 
 
 def get_html_theme_path():

--- a/f5_sphinx_theme/static/js/survey-monkey.js
+++ b/f5_sphinx_theme/static/js/survey-monkey.js
@@ -38,7 +38,7 @@ $(document).ready(function () {
     } else if (urlPathNames.length == 2) {
       surveyMonkey.searchParams.append(surveyMonkeyVariableSite, urlPathNames[urlPathNames.length - 2]);
       surveyMonkey.searchParams.append(surveyMonkeyVariablePage, urlPathNames[urlPathNames.length - 1]);
-    } else if (urlPathNames.length == 3) {
+    } else if (urlPathNames.length >= 3) {
       surveyMonkey.searchParams.append(surveyMonkeyVariableSite, urlPathNames[urlPathNames.length - 3]);
       surveyMonkey.searchParams.append(surveyMonkeyVariableVersion, urlPathNames[urlPathNames.length - 2]);
       surveyMonkey.searchParams.append(surveyMonkeyVariablePage, urlPathNames[urlPathNames.length - 1]);


### PR DESCRIPTION
## Reviewers
@alankrit8 

## Issue 
Fixing a bug with SurveyMonkey enabled and the pathnames contain more than 3 paths, such as `https://cloud docs.f5.com/one/two/three/four`.

Fixes:

The logic needs to be changes from:
```js
else if (urlPathNames.length == 3)
```

to:

```js
else if (urlPathNames.length >= 3)
```