### PR TITLE
fix: Enable ability to exclude survey from appearing on specific pages when survey is enabled

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -25,6 +25,7 @@ Setup and Configuration
                             # 'surveymonkey_url' = '',                    \\ DEFAULTS TO ""
                             # 'medallia_embed_url' = '',                  \\ DEFAULTS TO ""
                             # 'medallia_id' = '',                         \\ DEFAULTS TO "medallia_inline_survey"
+                            # 'feedback_exclude_pages': ['page.html'],    \\ DEFAULTS TO ['index.html', 'search.html'], THE TABLE OF CONTENTS AND SEARCH PAGE
                             # 'base_url' = ''                             \\ DEFAULTS TO '/'
                          }
 

--- a/f5_sphinx_theme/__init__.py
+++ b/f5_sphinx_theme/__init__.py
@@ -16,7 +16,7 @@ import os
 from os import path
 
 
-__version__ = "2.2.0"
+__version__ = "2.2.1"
 
 
 def get_html_theme_path():

--- a/f5_sphinx_theme/layout.html
+++ b/f5_sphinx_theme/layout.html
@@ -135,13 +135,13 @@
           </div>
         </div>
         {% endif %}
-        {% if theme_medallia_embed_url %}
+        {% if theme_medallia_embed_url and (pagename+file_suffix) not in theme_feedback_exclude_pages %}
         <hr>
         <div id="{{ theme_medallia_id }}" class="medallia_survey">
         </div>
         <script type="text/javascript" src="{{ theme_medallia_embed_url }}" async></script>
         {% endif %}
-        {% if theme_surveymonkey_url %}
+        {% if theme_surveymonkey_url and (pagename+file_suffix) not in theme_feedback_exclude_pages %}
         <hr>
         <div id="survey-sm-div" survey-sm-url="{{ theme_surveymonkey_url }}">
           <a id="survey-sm" target="_blank" rel="noopener noreferrer">Click here to provide feedback</a>
@@ -165,7 +165,8 @@
 {% if (theme_version_selector) %}
 <script src="{{ pathto('_static/js/index.js', 1) }}"></script>
 {%- endif %}
-{% if (theme_surveymonkey_url or theme_medallia_embed_url) %}
+{% if (theme_surveymonkey_url or theme_medallia_embed_url) and (pagename+file_suffix) not in
+theme_feedback_exclude_pages %}
 <script src="{{ pathto('_static/js/feedback.js', 1) }}"></script>
 {%- endif %}
 <script src="{{ pathto('_static/js/jquery.appear.js', 1) }}"></script>

--- a/f5_sphinx_theme/static/js/feedback.js
+++ b/f5_sphinx_theme/static/js/feedback.js
@@ -16,7 +16,6 @@ const surveyMonkeyAId = "survey-sm";
 const surveyMonkeyUrlAttr = 'survey-sm-url';
 
 const htmlString = ".html";
-const htmlDefaultIndex = "index.html";
 
 // 'window' is a global variable. Define 'medalliaData' global variable here.
 var medalliaData = {};
@@ -49,16 +48,8 @@ function renderSM(smDiv) {
   const url = new URL(window.location.href);
   const urlPathNames = url.pathname.split('/').filter(Boolean);
 
-  // If this is an 'index.html' or isn't even an html page, hide the SurveyMonkey link.
-  if (url.pathname.trim().endsWith(htmlDefaultIndex) || !url.pathname.endsWith(htmlString)) {
-    console.debug('This page need to hide SurveyMonkey link')
-    // Hide the SurveyMonkey Div because this pages doesn't need it.
-    if (smDiv != null) {
-      $("#" + surveyMonkeyDivId).hide();
-    }
-  }
   // Otherwise determine the custom variables for SurveyMonkey.
-  else if (urlPathNames[urlPathNames.length - 1].endsWith(htmlString)) {
+  if (urlPathNames[urlPathNames.length - 1].endsWith(htmlString)) {
     if (urlPathNames.length == 1) {
       surveyMonkey.searchParams.append(data.surveyMonkey.page, urlPathNames[urlPathNames.length - 1]);
     } else if (urlPathNames.length == 2) {

--- a/f5_sphinx_theme/theme.conf
+++ b/f5_sphinx_theme/theme.conf
@@ -11,3 +11,4 @@ enable_version_warning_banner = False
 surveymonkey_url =
 medallia_embed_url =
 medallia_id = medallia_inline_survey
+feedback_exclude_pages = ['index.html', 'search.html']


### PR DESCRIPTION
## Reviewers
@alankrit8 
@brentmcomer 

### Describe the change(s) made and why

When a Medallia or SurveyMonkey is enabled, there wasn't the ability to exclude specific pages that don't need a survey, like the *table of contents*.

This PR addresses that issue by allowing users to exclude specific pages via a new `html_theme_options` called `feedback_exclude_pages`.

The `feedback_exclude_pages` variable defaults to `['index.html', 'search.html']` which are the *table of contents* and the *search* pages.

An example of how a user would setup their own `feedback_exclude_pages` is below where they don't want the survey to appear on `custom.html`:
```py
html_theme_options = {
    'feedback_exclude_pages': ['index.html',
                               'search.html',
                               'custom.html']
 }
```

