### PR TITLE
feat: add a 'last updated' line on all content

### DIFF
--- a/f5_sphinx_theme/__init__.py
+++ b/f5_sphinx_theme/__init__.py
@@ -16,7 +16,7 @@ import os
 from os import path
 
 
-__version__ = "2.2.2"
+__version__ = "2.2.3"
 
 
 def get_html_theme_path():

--- a/f5_sphinx_theme/layout.html
+++ b/f5_sphinx_theme/layout.html
@@ -119,6 +119,9 @@
 
 
         <div role="main">
+          {%- if last_updated %}
+          {% trans last_updated=last_updated|e %}Last updated on: {{ last_updated }}.{% endtrans %}
+          {%- endif %}
           {% block body %}{% endblock %}
         </div>
         {% if (next or prev) and (theme_next_prev_link) %}


### PR DESCRIPTION
## Reviewers
@alankrit8. 

## Issue 
We want to know when a page was last updated. This help people get an idea how old or new pages are.

The format of last updated can be defined in `conf.py` file. Example below.

```python
html_last_updated_fmt = '%B %d %Y at %I:%M:%S %p %Z'
```

And if you want to pin a timezone:
```python
html_last_updated_fmt = '%B %d %Y at %I:%M:%S %p %Z'
git_last_updated_timezone = 'US/Pacific'

extensions = [
    . . .
    'sphinx_last_updated_by_git',
]
```

Screenshot:
<img width="1151" alt="image" src="https://user-images.githubusercontent.com/62568830/213801280-3b1d4366-977d-43c7-addc-a89cf5a5a467.png">


