### PR TITLE
Added ability to override 'maxdepth' on sidebar

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -22,11 +22,12 @@ Setup and Configuration
                             'site_name': '<desired site name>',           \\ DEFAULTS TO "CloudDocs home"
                             'next_prev_link': True or False,              \\ DEFAULTS TO FALSE
                             'html_last_updated_fmt': '%Y-%m-%d %H:%M:%S', \\ REQUIRED FOR FEDERATED SEARCH, DO NOT CHANGE
-                            # 'surveymonkey_url' = '',                    \\ DEFAULTS TO ""
-                            # 'medallia_embed_url' = '',                  \\ DEFAULTS TO ""
+                            # 'surveymonkey_url' = '',                    \\ DEFAULTS TO ''
+                            # 'medallia_embed_url' = '',                  \\ DEFAULTS TO ''
                             # 'medallia_id' = '',                         \\ DEFAULTS TO "medallia_inline_survey"
                             # 'feedback_exclude_pages': ['page.html'],    \\ DEFAULTS TO ['index.html', 'search.html'], THE TABLE OF CONTENTS AND SEARCH PAGE
-                            # 'base_url' = ''                             \\ DEFAULTS TO '/'
+                            # 'base_url' = ''                             \\ DEFAULTS TO '/',
+                            # 'sidebar_toc_maxdepth' = ''                 \\ DEFAULTS TO '', Override 'maxdepth' behavior on sidebar toc in layout.html. This is an integer value.
                          }
 
    \

--- a/f5_sphinx_theme/__init__.py
+++ b/f5_sphinx_theme/__init__.py
@@ -16,7 +16,7 @@ import os
 from os import path
 
 
-__version__ = "2.2.3"
+__version__ = "2.2.4"
 
 
 def get_html_theme_path():

--- a/f5_sphinx_theme/layout.html
+++ b/f5_sphinx_theme/layout.html
@@ -69,7 +69,7 @@
         {%- include "searchbox.html" %}
         <hr>
         <span class="nav-sidebartoc">
-          {{ toctree(includehidden=True, collapse=True) }}
+          {{ toctree(includehidden=True, collapse=True, maxdepth=theme_sidebar_toc_maxdepth|int) }}
         </span>
         {%- include "extralinks.html" %}
       </nav>

--- a/f5_sphinx_theme/theme.conf
+++ b/f5_sphinx_theme/theme.conf
@@ -12,3 +12,4 @@ surveymonkey_url =
 medallia_embed_url =
 medallia_id = medallia_inline_survey
 feedback_exclude_pages = ['index.html', 'search.html']
+sidebar_toc_maxdepth =


### PR DESCRIPTION
## Reviewers
@alankrit8 

### Describe the problem/feature to which this change applies
Our Technical Reference Manual (TRM) needs different `maxdepth` behavior depending if we are looking at the main window or the sidebar. The team needed to refine the page layout

### Describe the change(s) made and why
We want the main `index.html` page to have a **maxdepth** of 1 but the sidebar to use a **maxdepth** of 2. Current behavior ties both these together but TRMs would like this behavior.

Below are the screenshots we want.

Main window **maxdepth** of 1. 
![image](https://user-images.githubusercontent.com/62568830/221027783-581f0665-5897-4a1c-b395-ca5769128baa.png)

AND side window to use **maxdepth** of 2.
![image](https://user-images.githubusercontent.com/62568830/221028054-5035ab98-db90-4ab0-b9d2-55eb23837436.png)


