### PR TITLE
Fix Subsite and Version Assignment

### DIFF
--- a/f5_sphinx_theme/__init__.py
+++ b/f5_sphinx_theme/__init__.py
@@ -16,7 +16,7 @@ import os
 from os import path
 
 
-__version__ = "2.2.4"
+__version__ = "2.2.5"
 
 
 def get_html_theme_path():

--- a/f5_sphinx_theme/static/js/feedback.js
+++ b/f5_sphinx_theme/static/js/feedback.js
@@ -56,7 +56,7 @@ function renderSM(smDiv) {
       surveyMonkey.searchParams.append(data.surveyMonkey.site, urlPathNames[urlPathNames.length - 2]);
       surveyMonkey.searchParams.append(data.surveyMonkey.page, urlPathNames[urlPathNames.length - 1]);
     } else if (urlPathNames.length >= 3) {
-      surveyMonkey.searchParams.append(data.surveyMonkey.site, urlPathNames[urlPathNames.length - 3]);
+      surveyMonkey.searchParams.append(data.surveyMonkey.site, urlPathNames[0]); // Assume first field is the project/subsite
       surveyMonkey.searchParams.append(data.surveyMonkey.version, urlPathNames[urlPathNames.length - 2]);
       surveyMonkey.searchParams.append(data.surveyMonkey.page, urlPathNames[urlPathNames.length - 1]);
     }
@@ -84,7 +84,7 @@ function renderMedallia() {
     medalliaDataSite = urlPathNames[urlPathNames.length - 2];
     medalliaDataPage = urlPathNames[urlPathNames.length - 1];
   } else if (urlPathNames.length >= 3) {
-    medalliaDataSite = urlPathNames[urlPathNames.length - 3];
+    medalliaDataSite = urlPathNames[0]; // Assume first field is the project/subsite
     medalliaDataVersion = urlPathNames[urlPathNames.length - 2];
     medalliaDataPage = urlPathNames[urlPathNames.length - 1];
   }

--- a/f5_sphinx_theme/static/js/feedback.js
+++ b/f5_sphinx_theme/static/js/feedback.js
@@ -50,16 +50,18 @@ function renderSM(smDiv) {
 
   // Otherwise determine the custom variables for SurveyMonkey.
   if (urlPathNames[urlPathNames.length - 1].endsWith(htmlString)) {
-    if (urlPathNames.length == 1) {
-      surveyMonkey.searchParams.append(data.surveyMonkey.page, urlPathNames[urlPathNames.length - 1]);
-    } else if (urlPathNames.length == 2) {
-      surveyMonkey.searchParams.append(data.surveyMonkey.site, urlPathNames[urlPathNames.length - 2]);
-      surveyMonkey.searchParams.append(data.surveyMonkey.page, urlPathNames[urlPathNames.length - 1]);
-    } else if (urlPathNames.length >= 3) {
-      surveyMonkey.searchParams.append(data.surveyMonkey.site, urlPathNames[0]); // Assume first field is the project/subsite
-      surveyMonkey.searchParams.append(data.surveyMonkey.version, urlPathNames[urlPathNames.length - 2]);
+    const smVersion = document.querySelector('meta[name="version"]').content;
+    surveyMonkey.searchParams.append(data.surveyMonkey.site, document.querySelector('meta[name="product"]').content);
+    surveyMonkey.searchParams.append(data.surveyMonkey.site, smVersion);
+
+    if (urlPathNames.length >= 1) {
       surveyMonkey.searchParams.append(data.surveyMonkey.page, urlPathNames[urlPathNames.length - 1]);
     }
+
+    if (!smVersion && urlPathNames.length >= 3) {
+      surveyMonkey.searchParams.append(data.surveyMonkey.version, urlPathNames[urlPathNames.length - 2]);
+    }
+
     // Modify SurveyMonkey href.
     var surveyMonkeyLink = document.getElementById(surveyMonkeyAId);
     if (surveyMonkeyLink != null) {
@@ -78,15 +80,17 @@ function renderMedallia() {
   const urlPathNames = url.pathname.split('/').filter(Boolean);
 
   // Assign subsite, page, and version information.
-  if (urlPathNames.length == 1) {
+  medalliaDataSite = document.querySelector('meta[name="product"]').content
+  medalliaDataVersion = document.querySelector('meta[name="version"]').content
+
+  // The medalliaDataPage is set by looking at the URL. It will be the last element.
+  if (urlPathNames.length >= 1) {
     medalliaDataPage = urlPathNames[urlPathNames.length - 1];
-  } else if (urlPathNames.length == 2) {
-    medalliaDataSite = urlPathNames[urlPathNames.length - 2];
-    medalliaDataPage = urlPathNames[urlPathNames.length - 1];
-  } else if (urlPathNames.length >= 3) {
-    medalliaDataSite = urlPathNames[0]; // Assume first field is the project/subsite
+  }
+
+  // If the medalliaDataVersion isn't set, try to set it by looking at the URL on the second to last element.
+  if (!medalliaDataVersion && urlPathNames.length >= 3) {
     medalliaDataVersion = urlPathNames[urlPathNames.length - 2];
-    medalliaDataPage = urlPathNames[urlPathNames.length - 1];
   }
 
   // Set HTML global variable medalliaData.


### PR DESCRIPTION
## Reviewers
@alankrit8 

## Issue 
Projects that have a URL structure like below will not have the correct `subsite` value.
https://clouddocs.f5.com/f5os/F5OS-C/v1.0.0/F5OS-C-1.0.0-CX410-Chassis-and-BX110-Blade-Hardware-Overview.html

Currently, `subsite` = `F5OS-C`. But we want `subsite` = `f5os`. Doing this isn't very trivial because paths for all projects seem to be different all across the board... We need to look at another place when we set this `subsite` variable.

Fixes:

Change how to **medalliaData.subsite** and **medalliaData.version** is set.
1. For **medalliaData.subsite**, the value from `project` in `conf.py` will be used.
2. For **medalliaData.version**, the value from `version` or `release` in `conf.py` will be used. If it is blank, then it will try to parse it from the URL.



