### PR TITLE
feat: Adding Ability to Hide Right Menu

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -144,3 +144,6 @@ f5_sphinx_theme/static/js/index.js
 
 # ignore virtual env
 venv*
+
+# Ignore Mac temp file
+**/.DS_Store

--- a/README.rst
+++ b/README.rst
@@ -28,6 +28,7 @@ Setup and Configuration
                             # 'feedback_exclude_pages': ['page.html'],    \\ DEFAULTS TO ['index.html', 'search.html'], THE TABLE OF CONTENTS AND SEARCH PAGE
                             # 'base_url' = ''                             \\ DEFAULTS TO '/',
                             # 'sidebar_toc_maxdepth' = ''                 \\ DEFAULTS TO '', Override 'maxdepth' behavior on sidebar toc in layout.html. This is an integer value.
+                            # 'hide_right_menu': True or False,           \\ DEFAULTS TO FALSE
                          }
 
    \

--- a/f5_sphinx_theme/__init__.py
+++ b/f5_sphinx_theme/__init__.py
@@ -16,7 +16,7 @@ import os
 from os import path
 
 
-__version__ = "2.2.5"
+__version__ = "2.3.0"
 
 
 def get_html_theme_path():

--- a/f5_sphinx_theme/layout.html
+++ b/f5_sphinx_theme/layout.html
@@ -75,7 +75,7 @@
       </nav>
     </div>
 
-
+    {%- if not theme_hide_right_menu %}
     <div id="right-sidebar">
       <h7 style="font-weight:normal">On this page:</h7>
       <nav class="nav-sidebartoc">
@@ -84,7 +84,7 @@
         </span>
       </nav>
     </div>
-
+    {%- endif %}
 
     {%- endblock %}
     {%- endif %}
@@ -94,7 +94,9 @@
 
 
     {% block main %}
-    <div class="main active" id="content">
+
+    <div class="main active" id="content" {% if theme_hide_right_menu %}hide-right-menu{% endif %}>
+
       <article class="docs-container site-article-inner">
 
         {%- block breadcrumb %}

--- a/f5_sphinx_theme/static/css/f5-theme.css
+++ b/f5_sphinx_theme/static/css/f5-theme.css
@@ -62,9 +62,13 @@ a.copybtn {
     min-height: 728px;
   }
 
-  #content.active {
+  #content.active:not([hide-right-menu]) {
     margin-left: 315px;
     margin-right: 275px
+  }
+
+  #content.active[hide-right-menu] {
+    margin-left: 315px;
   }
 }
 

--- a/f5_sphinx_theme/static/js/clouddocs.js
+++ b/f5_sphinx_theme/static/js/clouddocs.js
@@ -1,11 +1,11 @@
 // Use the header and footer from the current host (clouddocs.f5.com or clouddocs.f5networks.net)
 $(document).ready(function () {
-    var loc = window.location,
+  var loc = window.location,
     host = loc.protocol + '//' + loc.host;
-    $('#clouddocs-header').load(host + '/header.html', loadCoveoComponents);
-    $('#clouddocs-footer').load(host + '/footer.html');
+  $('#clouddocs-header').load(host + '/header.html', loadCoveoComponents);
+  $('#clouddocs-footer').load(host + '/footer.html');
 
-    Coveo.SearchEndpoint.configureCloudV2Endpoint('', 'xx564559b1-0045-48e1-953c-3addd1ee4457');
+  Coveo.SearchEndpoint.configureCloudV2Endpoint('', 'xx564559b1-0045-48e1-953c-3addd1ee4457');
 
 });
 
@@ -23,7 +23,7 @@ function loadCoveoComponents() {
   }
 
   // Event listener for click on search toggle button
-  document.getElementById('search-toggle').addEventListener('click', function() {
+  document.getElementById('search-toggle').addEventListener('click', function () {
     var searchContainer = document.getElementById('search-container');
     var isVisible = searchContainer.style.overflow === 'visible';
     // Toggle visibility
@@ -59,54 +59,54 @@ function hideSearchToggleBtn() {
 
 //Version Warning Banner
 
-function renderVersionWarning(){
+function renderVersionWarning() {
 
-    $.getJSON( "../versions.json", function(versionsJson) {
+  $.getJSON("../versions.json", function (versionsJson) {
 
-        var pathes = document.location.pathname.split("/");
-        pathes.pop();
+    var pathes = document.location.pathname.split("/");
+    pathes.pop();
 
-        var versionUrlPathes = versionsJson.latestVersion.url.split("/");
-        versionUrlPathes.pop();
+    var versionUrlPathes = versionsJson.latestVersion.url.split("/");
+    versionUrlPathes.pop();
 
-        var currentPath = pathes.slice(0, versionUrlPathes.length).join("/") + "/";
+    var currentPath = pathes.slice(0, versionUrlPathes.length).join("/") + "/";
 
-        if(currentPath != versionsJson.latestVersion.url){
+    if (currentPath != versionsJson.latestVersion.url) {
 
-            for (var index in versionsJson.otherVersions){
+      for (var index in versionsJson.otherVersions) {
 
-                if(versionsJson.otherVersions[index].url == currentPath){
+        if (versionsJson.otherVersions[index].url == currentPath) {
 
-                    $("#version-warning").show();
-                    $("#currentVersion").text("This content applies to " + versionsJson.otherVersions[index].name);
-
-                }
-
-            }
+          $("#version-warning").show();
+          $("#currentVersion").text("This content applies to " + versionsJson.otherVersions[index].name);
 
         }
 
+      }
 
-    });
+    }
+
+
+  });
 }
 
 // Export PDF
 
-function exportPdf(){
+function exportPdf() {
 
 
-        var pathes = document.location.pathname.split("/");
-        pathes.pop();
+  var pathes = document.location.pathname.split("/");
+  pathes.pop();
 
-        $("#content").printThis({
-            importCSS : true,
-            importStyle : true,
-            base: '//' + document.location.host + pathes.join("/") + "/",
-            removeScripts: true,
-            beforePrint : function() { $("#export-pdf").hide(); $(".row, .next-prev-btn-row").hide(); },
-            afterPrint : function() { $("#export-pdf").show(); $(".row, .next-prev-btn-row").show(); },
-            printDelay : 600
-        });
+  $("#content").printThis({
+    importCSS: true,
+    importStyle: true,
+    base: '//' + document.location.host + pathes.join("/") + "/",
+    removeScripts: true,
+    beforePrint: function () { $("#export-pdf").hide(); $(".row, .next-prev-btn-row").hide(); },
+    afterPrint: function () { $("#export-pdf").show(); $(".row, .next-prev-btn-row").show(); },
+    printDelay: 600
+  });
 
 }
 
@@ -117,67 +117,67 @@ function exportPdf(){
 var navBars_hrefs = []
 
 
-function updateHighlights(id, isAppeared){
+function updateHighlights(id, isAppeared) {
 
-   $("#sidebar a[href='#']").filter("[class*=reference]").css( "color", "#1d9cd3" );
+  $("#sidebar a[href='#']").filter("[class*=reference]").css("color", "#1d9cd3");
 
 
-    if(isAppeared){
+  if (isAppeared) {
 
-        if(navBars_hrefs[0] == id){
+    if (navBars_hrefs[0] == id) {
 
-             $("#right-sidebar a[href='#']").filter("[class*=reference]").css( "color", "#1d9cd3" );
+      $("#right-sidebar a[href='#']").filter("[class*=reference]").css("color", "#1d9cd3");
 
-        }else{
+    } else {
 
-             $("#right-sidebar a[href$='" + id + "']").filter("[class*=reference]").css( "color", "#1d9cd3" );
-        }
+      $("#right-sidebar a[href$='" + id + "']").filter("[class*=reference]").css("color", "#1d9cd3");
+    }
 
-    }else{
+  } else {
 
-        if(navBars_hrefs[0] == id){
+    if (navBars_hrefs[0] == id) {
 
-             $("#right-sidebar a[href='#']").filter("[class*=reference]").css( "color", "black" );
+      $("#right-sidebar a[href='#']").filter("[class*=reference]").css("color", "black");
 
-        }else{
+    } else {
 
-             $("#right-sidebar a[href$='" + id + "']").filter("[class*=reference]").css( "color", "black" );
-
-        }
+      $("#right-sidebar a[href$='" + id + "']").filter("[class*=reference]").css("color", "black");
 
     }
+
+  }
 
 
 }
 
 
 
-function triggerSideBarHighlighting(){
+function triggerSideBarHighlighting() {
 
-       var higlightedItem = navBars_hrefs[0];
+  var higlightedItem = navBars_hrefs[0];
 
-        for(var i=0; i < navBars_hrefs.length; i++){
+  for (var i = 0; i < navBars_hrefs.length; i++) {
 
-            if($(navBars_hrefs[i]).is(':appeared')){
-
-
-                if($(navBars_hrefs[i]).offset().top - ($("#clouddocs-header").height()) < $(this).scrollTop()){
-
-                    higlightedItem = navBars_hrefs[i];
-
-                }
+    if ($(navBars_hrefs[i]).is(':appeared')) {
 
 
-                updateHighlights(navBars_hrefs[i], false);
+      if ($(navBars_hrefs[i]).offset().top - ($("#clouddocs-header").height()) < $(this).scrollTop()) {
 
-            }else{
+        higlightedItem = navBars_hrefs[i];
 
-                updateHighlights(navBars_hrefs[i], false);
-            }
+      }
 
-        }
 
-        updateHighlights(higlightedItem, true);
+      updateHighlights(navBars_hrefs[i], false);
+
+    } else {
+
+      updateHighlights(navBars_hrefs[i], false);
+    }
+
+  }
+
+  updateHighlights(higlightedItem, true);
 
 }
 
@@ -185,6 +185,10 @@ function triggerSideBarHighlighting(){
 var originalRightSideBarHeight = $("#right-sidebar").innerHeight() - 80;
 
 function resizeRightScrollbar() {
+  var rightScrollBarExists = document.getElementById("right-sidebar");
+  if (rightScrollBarExists == false) {
+    return;
+  }
 
   //get the right-sidebar bottom offset and the footer top offset
   var rightSidebarBottom = $("#right-sidebar").offset().top + $("#right-sidebar").outerHeight(true) - 25;
@@ -198,30 +202,30 @@ function resizeRightScrollbar() {
     //$("#right-sidebar").css("overflow-y", "scroll");
 
 
-  //checks if the footer has moved away, so the right-sidebar needs to grow back
-  }else if($("#right-sidebar").height() < originalRightSideBarHeight) {
-    var tallerNewHeight  = $("#right-sidebar").height() + (footerTop - rightSidebarBottom);
+    //checks if the footer has moved away, so the right-sidebar needs to grow back
+  } else if ($("#right-sidebar").height() < originalRightSideBarHeight) {
+    var tallerNewHeight = $("#right-sidebar").height() + (footerTop - rightSidebarBottom);
 
-    if($(".footer").is(':appeared')){
+    if ($(".footer").is(':appeared')) {
 
-        if (rightSidebarBottom >= footerTop){
+      if (rightSidebarBottom >= footerTop) {
 
-            $("#right-sidebar").height(tallerNewHeight);
+        $("#right-sidebar").height(tallerNewHeight);
 
-        }
+      }
 
 
-    }else{
+    } else {
 
-        $("#right-sidebar").height(originalRightSideBarHeight);
-        //$("#right-sidebar").css("overflow-y", "hidden");
+      $("#right-sidebar").height(originalRightSideBarHeight);
+      //$("#right-sidebar").css("overflow-y", "hidden");
 
     }
 
 
   }
 
-  if($("#right-sidebar").height() < 140) {
+  if ($("#right-sidebar").height() < 140) {
     console.log("height is too short!");
     $("#right-sidebar").height(160);
   }
@@ -233,155 +237,155 @@ function resizeRightScrollbar() {
 $(document).ready(function () {
 
 
-    //Right Sidebar related items
-    $("#version-warning").hide();
+  //Right Sidebar related items
+  $("#version-warning").hide();
 
 
-    $(window).resize(function(evt) {
+  $(window).resize(function (evt) {
 
-        if(evt.target.innerWidth > 1271 && $("#sidebar").hasClass("active") && !$("#content").hasClass("active")){
+    if (evt.target.innerWidth > 1271 && $("#sidebar").hasClass("active") && !$("#content").hasClass("active")) {
 
-            $("#content").toggleClass("active");
-            $("#sidebar").toggleClass("active");
+      $("#content").toggleClass("active");
+      $("#sidebar").toggleClass("active");
 
-        }
+    }
 
-    });
+  });
 
-    // Collect all href value
-    navBars_hrefs = []
+  // Collect all href value
+  navBars_hrefs = []
 
-    $("#right-sidebar a").each(function(index){
+  $("#right-sidebar a").each(function (index) {
 
-        if ($(this).attr("href") == "#"){
+    if ($(this).attr("href") == "#") {
 
-           navBars_hrefs.push("#"  + $(this).text().replace(": ", "-").replace(/ /g,"-").replace("/","-").toLowerCase());
+      navBars_hrefs.push("#" + $(this).text().replace(": ", "-").replace(/ /g, "-").replace("/", "-").toLowerCase());
 
-        }else{
+    } else {
 
-           navBars_hrefs.push($(this).attr("href").toLowerCase());
+      navBars_hrefs.push($(this).attr("href").toLowerCase());
 
-        }
+    }
 
-    });
+  });
 
-    $("#right-sidebar a").hover(function(e){
-
-
-        if(e.type == "mouseenter"){
-
-            try {
-
-                triggerSideBarHighlighting();
-
-            }catch(err){
-
-                console.log("%cException got caught on triggerSideBarHighlighting call: " + err, "color:red");
-
-            }
-
-            $(this).css("color", "#0c5c8d");
+  $("#right-sidebar a").hover(function (e) {
 
 
-        }else{
+    if (e.type == "mouseenter") {
 
-            $(this).css("color", "black")
-            try {
+      try {
 
-                triggerSideBarHighlighting();
+        triggerSideBarHighlighting();
 
-            }catch(err){
+      } catch (err) {
 
-                console.log("%cException got caught on triggerSideBarHighlighting call: " + err, "color:red");
+        console.log("%cException got caught on triggerSideBarHighlighting call: " + err, "color:red");
 
-            }
+      }
 
-        }
-
-    });
+      $(this).css("color", "#0c5c8d");
 
 
-    //OnScroll event listener
-    $(window).scroll(function(){
+    } else {
 
-        try {
+      $(this).css("color", "black")
+      try {
 
-            triggerSideBarHighlighting();
+        triggerSideBarHighlighting();
 
-        }catch(err){
+      } catch (err) {
 
-            console.log("%cException got caught on triggerSideBarHighlighting call: " + err, "color:red");
+        console.log("%cException got caught on triggerSideBarHighlighting call: " + err, "color:red");
 
-        }
+      }
 
-        try {
+    }
 
-            resizeRightScrollbar();
+  });
 
-        }catch(err){
 
-            console.log("%cException got caught on resizeRightScrollbar call: " + err, "color:red");
-
-        }
-
-    });
-
+  //OnScroll event listener
+  $(window).scroll(function () {
 
     try {
 
-        resizeRightScrollbar();
+      triggerSideBarHighlighting();
 
-    }catch(err){
+    } catch (err) {
 
-        console.log("%cException got caught on resizeRightScrollbar call: " + err, "color:red");
+      console.log("%cException got caught on triggerSideBarHighlighting call: " + err, "color:red");
 
     }
 
     try {
 
-         triggerSideBarHighlighting();
+      resizeRightScrollbar();
 
-    }catch(err){
+    } catch (err) {
 
-         console.log("%cException got caught on triggerSideBarHighlighting call: " + err, "color:red");
-
-    }
-
-    try {
-
-        if($("#version_selector_wrapper").length){
-
-             renderVersionWarning();
-
-        }
-
-    }catch(err){
-
-         console.log("%cException got caught on renderVersionWarning call: " + err, "color:red");
+      console.log("%cException got caught on resizeRightScrollbar call: " + err, "color:red");
 
     }
 
-    // PDF Export
-    $("#export-pdf").click(exportPdf);
+  });
 
 
-    $('#sidebarCollapse, #dismiss').on('click', function () {
-        $('#sidebar').toggleClass('active');
-        $('#content').toggleClass('active');
-    });
+  try {
 
-    //Used to check that the megamenu exists. When user hovers over menu, changes z-index of TOC so
-    //it does not overlap the megamenu
-    var checkExist = setInterval(function() {
-       if ($('#MainMenu').length) {
-         $("#MainMenu").hover(function(){
-           $('#sidebar').css("z-index", "-1");
-           }, function(){
-           $('#sidebar').css("z-index", "0");
-         });
-        clearInterval(checkExist);
-       }
-    }, 500); // check every 500ms
+    resizeRightScrollbar();
+
+  } catch (err) {
+
+    console.log("%cException got caught on resizeRightScrollbar call: " + err, "color:red");
+
+  }
+
+  try {
+
+    triggerSideBarHighlighting();
+
+  } catch (err) {
+
+    console.log("%cException got caught on triggerSideBarHighlighting call: " + err, "color:red");
+
+  }
+
+  try {
+
+    if ($("#version_selector_wrapper").length) {
+
+      renderVersionWarning();
+
+    }
+
+  } catch (err) {
+
+    console.log("%cException got caught on renderVersionWarning call: " + err, "color:red");
+
+  }
+
+  // PDF Export
+  $("#export-pdf").click(exportPdf);
+
+
+  $('#sidebarCollapse, #dismiss').on('click', function () {
+    $('#sidebar').toggleClass('active');
+    $('#content').toggleClass('active');
+  });
+
+  //Used to check that the megamenu exists. When user hovers over menu, changes z-index of TOC so
+  //it does not overlap the megamenu
+  var checkExist = setInterval(function () {
+    if ($('#MainMenu').length) {
+      $("#MainMenu").hover(function () {
+        $('#sidebar').css("z-index", "-1");
+      }, function () {
+        $('#sidebar').css("z-index", "0");
+      });
+      clearInterval(checkExist);
+    }
+  }, 500); // check every 500ms
 
 });
 
@@ -391,7 +395,7 @@ function resizeScrollbar() {
   var contentHeight = 0;
   if ($(".nav-sidebartoc").height() < parseInt($("#sidebar").css('max-height'))) {
     contentHeight = $(".nav-sidebartoc").height();
-  }else {
+  } else {
     contentHeight = $("#sidebar").css('max-height');
   }
   contentHeight = parseInt(contentHeight);
@@ -405,17 +409,17 @@ function resizeScrollbar() {
     var shorterNewHeight = $("#sidebar").height() - (sidebarBottom - footerTop) - 40;
     $("#sidebar").height(shorterNewHeight);
 
-  //checks if the footer has moved away, so the sidebar needs to grow back
-  }else if($("#sidebar").height() < contentHeight) {
+    //checks if the footer has moved away, so the sidebar needs to grow back
+  } else if ($("#sidebar").height() < contentHeight) {
     var tallerNewHeight = $("#sidebar").height() + (footerTop - sidebarBottom) - 40;
     if (tallerNewHeight > contentHeight) {
       $("#sidebar").height(contentHeight + 40);
-    }else {
+    } else {
       $("#sidebar").height(tallerNewHeight);
     }
   }
 
-  if($("#sidebar").height() < 140) {
+  if ($("#sidebar").height() < 140) {
     console.log("height is too short!");
     $("#sidebar").height(160);
   }
@@ -426,55 +430,55 @@ $(document).ready(function () {
 
   /* JavaScript Media Queries, check if mobile view and do not resize TOC */
   if (matchMedia) {
-  	const mq = window.matchMedia("(max-width: 768px)");
-  	mq.addListener(WidthChange);
-  	WidthChange(mq);
+    const mq = window.matchMedia("(max-width: 768px)");
+    mq.addListener(WidthChange);
+    WidthChange(mq);
   }
 
   // Checks if resize TOC should be called when page is resized
   function WidthChange(mq) {
-  	if (!mq.matches) {
+    if (!mq.matches) {
       console.log("im resizing the TOC");
-  	  resizeScrollbar();
-  	}
+      resizeScrollbar();
+    }
   }
 
   //Throttle for scroll
-  $(window).scroll(function() {
-  clearTimeout($.data(this, 'scrollTimer'));
-    $.data(this, 'scrollTimer', setTimeout(function() {
+  $(window).scroll(function () {
+    clearTimeout($.data(this, 'scrollTimer'));
+    $.data(this, 'scrollTimer', setTimeout(function () {
       resizeScrollbar();
-  }, 250));
+    }, 250));
   });
 });
 
-  //collapse/show sidebar toc content
-  $(document).ready(function () {
+//collapse/show sidebar toc content
+$(document).ready(function () {
 
-    //find the right li element, check if they have a ul and content, and add the button
-    $('.nav-sidebartoc li').has('ul').each(function(index) {
-      if ($(this).children('ul').children('li').length >= 1) {
-        var $btn = $('<i/>', {
-            class: 'collapseButton fa fa-caret-down',
-        })
-        $(this).prepend($btn);
-        $(this).addClass("nestedList");
-      }
-    });
+  //find the right li element, check if they have a ul and content, and add the button
+  $('.nav-sidebartoc li').has('ul').each(function (index) {
+    if ($(this).children('ul').children('li').length >= 1) {
+      var $btn = $('<i/>', {
+        class: 'collapseButton fa fa-caret-down',
+      })
+      $(this).prepend($btn);
+      $(this).addClass("nestedList");
+    }
+  });
 
-    //when the button is clicked do this
-    $('.collapseButton').click(function() {
-      var el = $(this);
+  //when the button is clicked do this
+  $('.collapseButton').click(function () {
+    var el = $(this);
 
-      //hide/show the ul
-      el.siblings('ul').slideToggle();
+    //hide/show the ul
+    el.siblings('ul').slideToggle();
 
-      //check what text the button has and change class appropriately (-/+)
-      if (el.hasClass('fa-caret-down')) {
-        el.removeClass('fa-caret-down').addClass('fa-caret-right');
-      } else {
-        el.removeClass('fa-caret-right').addClass('fa-caret-down');
-      }
-      return false;
+    //check what text the button has and change class appropriately (-/+)
+    if (el.hasClass('fa-caret-down')) {
+      el.removeClass('fa-caret-down').addClass('fa-caret-right');
+    } else {
+      el.removeClass('fa-caret-right').addClass('fa-caret-down');
+    }
+    return false;
   });
 });

--- a/f5_sphinx_theme/theme.conf
+++ b/f5_sphinx_theme/theme.conf
@@ -13,3 +13,4 @@ medallia_embed_url =
 medallia_id = medallia_inline_survey
 feedback_exclude_pages = ['index.html', 'search.html']
 sidebar_toc_maxdepth =
+hide_right_menu =


### PR DESCRIPTION
## Reviewers
@alankrit8 

There was a request to remove the right-side menu from appearing so adding an option to allow that.

In order to do this, you can add the following option to hide the right-side menu. Be default, right-side menu is enabled by default.

```python
html_theme_options = {
    'hide_right_menu': True,
}
```

Below is an example screenshot showing a website with the right-side menu hidden.
![image](https://github.com/f5devcentral/f5-sphinx-theme/assets/62568830/e9ae3ed8-d886-4b06-a63b-5a322f3c0738)



