### PR TITLE
feat: adding abliity to remove Next and Previous buttons on all 'inde…

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -29,13 +29,14 @@ Setup and Configuration
                             # 'base_url' = ''                             \\ DEFAULTS TO '/',
                             # 'sidebar_toc_maxdepth' = ''                 \\ DEFAULTS TO '', Override 'maxdepth' behavior on sidebar toc in layout.html. This is an integer value.
                             # 'hide_right_menu': True or False,           \\ DEFAULTS TO FALSE
+                            # 'next_prev_link_skip_index': True or False, \\ DEFAULTS TO FALSE. Hide Next and Previous buttons from all 'index' pages?
                          }
 
    \
 
    The ``base_url`` theme option is intended to allow customization of the root URL.
 
-  
+
 .. note::
 
    Depending on your publication/deployment process, you may have to re-build your documentation for the changes to take effect.

--- a/f5_sphinx_theme/__init__.py
+++ b/f5_sphinx_theme/__init__.py
@@ -16,7 +16,7 @@ import os
 from os import path
 
 
-__version__ = "2.3.0"
+__version__ = "2.4.0"
 
 
 def get_html_theme_path():

--- a/f5_sphinx_theme/layout.html
+++ b/f5_sphinx_theme/layout.html
@@ -126,7 +126,10 @@
           {%- endif %}
           {% block body %}{% endblock %}
         </div>
-        {% if (next or prev) and (theme_next_prev_link) %}
+        {% set pagename_list = pagename.split('/') %}
+        {% if (next or prev) and
+        (theme_next_prev_link) and
+        not (theme_next_prev_link_skip_index and 'index' in pagename_list ) %}
         <div class="row next-prev-btn-row">
           <div class="col-lg-12">
             {% if prev %}

--- a/f5_sphinx_theme/theme.conf
+++ b/f5_sphinx_theme/theme.conf
@@ -5,6 +5,7 @@ stylesheet = css/bootstrap.min.css
 [options]
 site_name = CloudDocs Home
 next_prev_link = False
+next_prev_link_skip_index = False
 version_selector = False
 base_url = /
 enable_version_warning_banner = False
@@ -13,4 +14,4 @@ medallia_embed_url =
 medallia_id = medallia_inline_survey
 feedback_exclude_pages = ['index.html', 'search.html']
 sidebar_toc_maxdepth =
-hide_right_menu =
+hide_right_menu = False

--- a/f5_sphinx_theme/theme.conf
+++ b/f5_sphinx_theme/theme.conf
@@ -5,7 +5,7 @@ stylesheet = css/bootstrap.min.css
 [options]
 site_name = CloudDocs Home
 next_prev_link = False
-next_prev_link_skip_index = False
+next_prev_link_skip_index =
 version_selector = False
 base_url = /
 enable_version_warning_banner = False
@@ -14,4 +14,4 @@ medallia_embed_url =
 medallia_id = medallia_inline_survey
 feedback_exclude_pages = ['index.html', 'search.html']
 sidebar_toc_maxdepth =
-hide_right_menu = False
+hide_right_menu =


### PR DESCRIPTION
There was an ask to remove the **Next** and **Previous** buttons from all 'index' pages. This PR allows the ability to do just that.

In order to enable this, be sure the set the following theme option below.
```python
html_theme_options = {
    'next_prev_link_skip_index': True,
}
```

Current behavior:
![image](https://github.com/f5devcentral/f5-sphinx-theme/assets/62568830/373ffb49-955c-4856-bad4-548bc86681b2)

New behavior with `'next_prev_link_skip_index': True,`. Notice the missing **Previous** and **Next** buttons:
![image](https://github.com/f5devcentral/f5-sphinx-theme/assets/62568830/1b4c1ca1-449f-447e-be76-b69de324ff04)

## Reviewers
@alankrit8 


