### PR TITLE
Add ability to show 'last_updated' on pages

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -29,6 +29,7 @@ Setup and Configuration
                             # 'sidebar_toc_maxdepth' = ''                 \\ DEFAULTS TO '', Override 'maxdepth' behavior on sidebar toc in layout.html. This is an integer value.
                             # 'hide_right_menu': True or False,           \\ DEFAULTS TO FALSE
                             # 'next_prev_link_skip_index': True or False, \\ DEFAULTS TO FALSE. Hide Next and Previous buttons from all 'index' pages?
+                            # 'display_last_updated': False,              \\ DEFAULTS TO FALSE.
                             # 'show_project': True,                       \\ DEFAULTS TO TRUE. Show project and version in left menu
                             # 'dropdown': {                               \\ DEFAULTS TO ''. Enable dropdown menu
                             #   'name': 'SPK v1.9.1',

--- a/f5_sphinx_theme/layout.html
+++ b/f5_sphinx_theme/layout.html
@@ -134,7 +134,7 @@
 
 
         <div role="main">
-          {%- if last_updated %}
+          {%- if last_updated and theme_display_last_updated %}
           {% trans last_updated=last_updated|e %}Last updated on: {{ last_updated }}.{% endtrans %}
           {%- endif %}
           {% block body %}{% endblock %}

--- a/f5_sphinx_theme/theme.conf
+++ b/f5_sphinx_theme/theme.conf
@@ -17,3 +17,4 @@ dropdown =
 sidebar_toc_maxdepth =
 hide_right_menu =
 show_project = True
+display_last_updated = False


### PR DESCRIPTION
## Reviewers
@alankrit8 

## Issue 
The sphinx theme defines `last_updated` as "[The build date](https://www.sphinx-doc.org/en/master/development/templating.html#last_updated)". Whenever a CloudDocs project is updated and published, `last_updated` will always be set to the date when Sphinx build ran. In other words, all pages will show the data it was publish from CI. This gives a false impression that content was updated when they have not.

Adding this new variable `theme_display_last_updated` will allow a user to decide if they want to show `last_updated`. Typically each page would show the last time it was updated (meaning when was the content last modified on a particular page), not when the page was compiled by Sphinx. For this to properly work, the [sphinx-last-updated-by-git](https://github.com/mgeier/sphinx-last-updated-by-git) extension is used.

Not all projects need to use this so this theme will not display this date by default



