### PR TITLE
Adding down arrow when version select button is displayed

### DIFF
--- a/f5_sphinx_theme/layout.html
+++ b/f5_sphinx_theme/layout.html
@@ -70,7 +70,7 @@
 
         {% if theme_dropdown | length != 0 %}
         <div class="dropdown">
-          <button class="dropbtn">{{ theme_dropdown["name"] }}</button>
+          <button class="dropbtn">{{ theme_dropdown["name"] }}<span class="downarrow"> &#8250;</span></button>
           <div class="dropdown-content">
             {% for name, link in theme_dropdown["links"].items() %}
             <a href={{link}}>{{name}}</a>
@@ -88,7 +88,7 @@
       </nav>
     </div>
 
-    {%- if not theme_hide_right_menu %}
+    {%- if not theme_hide_right_menu and not (theme_hide_right_menu_home and pagename == 'index') %}
     <div id="right-sidebar">
       <h7 style="font-weight:normal">On this page:</h7>
       <nav class="nav-sidebartoc">

--- a/f5_sphinx_theme/static/css/f5-theme.css
+++ b/f5_sphinx_theme/static/css/f5-theme.css
@@ -1369,10 +1369,30 @@ This section here is the css styling for the dropdown menu
   background-color: #002e63;
 }
 
+.dropbtn .downarrow {
+  /* Align vertically to the middle of the text */
+  display: inline-block;
+  vertical-align: middle;
+  /* Adjust the left margin for spacing */
+  margin-left: 8px;
+  transform: rotate(90deg);
+
+  /* Add more styles as needed */
+  color: lightgray;
+  /* Set the font size */
+  font-size: 30px;
+  /* Make the element an inline block */
+  display: inline-block;
+}
+
+/*********************************************************
+This section here is the css styling for the banner message
+**********************************************************/
+
 .clouddocs-banner {
   text-align: center;
   width: 100%;
-  background-color: #ffcc00;
+  background-color: #e4d07f;
   color: black;
   font-weight: bold;
 }

--- a/f5_sphinx_theme/theme.conf
+++ b/f5_sphinx_theme/theme.conf
@@ -16,6 +16,7 @@ feedback_exclude_pages = ['index.html', 'search.html']
 dropdown =
 sidebar_toc_maxdepth =
 hide_right_menu =
+hide_right_menu_home =
 show_project = True
 display_last_updated =
 banner_msg =


### PR DESCRIPTION
## Reviewers
@alankrit8 

There were **layout.html** updates in a project where a down arrow is also displayed on the multiple version box. Update this theme to include that down arrow by default.

![image](https://github.com/user-attachments/assets/83637ddb-32fe-4409-9c54-ad6677d951bc)
