### PR TITLE
Update upload-artifact version on publish action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Build a binary wheel and a source tarball
         run: python3 -m build
       - name: Store the distribution packages
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: python-package-distributions
           path: dist/


### PR DESCRIPTION
## Reviewers
N/A

## Issue 
N/A

Fixes:

### Describe the problem/feature to which this change applies
`upload-artifact@v3` is deprecated and needs an update - https://github.com/f5devcentral/f5-sphinx-theme/actions/runs/22474455359/job/65098389645.

### Describe the change(s) made and why
- Bump `upload-artifact` version to v4


