### PR TITLE
Add pypy3.11 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ jobs:
   test:
     strategy:
       matrix:
-        python-version: ["pypy3.9", "pypy3.10", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["pypy3.9", "pypy3.10", "pypy3.11", "3.9", "3.10", "3.11", "3.12"]
         os: ["ubuntu-22.04", "ubuntu-20.04"]
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
## Reviewers
N/A

## Issue 
N/A

Fixes:

### Describe the problem/feature to which this change applies
`pypy3.10` is not supported anymore.

### Describe the change(s) made and why
- Added `pypy3.11` to python version matrix.



