### PR TITLE
chore: Update download-artifact version on publish action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -42,7 +42,7 @@ jobs:
         id-token: write
     steps:
       - name: Download all the dists
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: python-package-distributions
           path: dist/


### PR DESCRIPTION
## Reviewers
N/A

## Issue 
N/A

Fixes:

### Describe the problem/feature to which this change applies
`dowbload-artifact@v3` is deprecated and needs an update - https://github.com/f5devcentral/f5-sphinx-theme/actions/runs/22474797731/job/65099442574.

### Describe the change(s) made and why
- Bump `download-artifact` version to v4


