### PR TITLE
Fix pypy incomp w/ Py03

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ jobs:
   test:
     strategy:
       matrix:
-        python-version: ["pypy3.9", "pypy3.10", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["pypy3.11", "3.9", "3.10", "3.11", "3.12"]
         os: ["ubuntu-22.04", "ubuntu-20.04"]
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
## Reviewers
N/A

## Issue 
N/A

Fixes:

### Describe the problem/feature to which this change applies
PyO3 does not support pypy3.9 and pypy3.10 - https://github.com/PyO3/pyo3/releases/tag/v0.27.0.

### Describe the change(s) made and why
- Remove old versions and added minimum support.


